### PR TITLE
Reverse order of Travis tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - mysql -e 'create database jobapps_test'
   - cp config/application.yml.example config/application.yml
   - cp config/database.yml.example config/database.yml
-script: 'bundle exec rake travis db:reset'
+script: 'bundle exec rake db:reset travis'
 notifications:
   email:
     recipients:


### PR DESCRIPTION
This fixed [a build failure](https://travis-ci.org/umts/ft-forms/builds/96624368) over on ft-forms.

Makes sense to (re)initialize the database before performing Rake tasks, anyway.