### PR TITLE
Interview can now be marked as hired or not.

### DIFF
--- a/app/assets/stylesheets/application_records/show.scss
+++ b/app/assets/stylesheets/application_records/show.scss
@@ -19,5 +19,5 @@
 }
 
 .note_item{
-  margin-top: 1em;
+  margin: 1em;
 }

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -5,6 +5,12 @@ class InterviewsController < ApplicationController
     if @interview.update completed: true
       show_message :interview_complete,
                    default: 'Interview marked as completed.'
+      if params[:hired]
+        @interview.update hired: true
+      else
+        @interview.update hired: false,
+                          interview_note: params[:interview_note]
+      end
       # TODO: some kind of API call to create users.
       redirect_to staff_dashboard_path
     else show_errors @interview

--- a/app/views/application_records/past_application_records.haml
+++ b/app/views/application_records/past_application_records.haml
@@ -1,11 +1,11 @@
 %table.data_table.display
   %thead
     %tr
-      %th= 'Date Submitted'
-      %th= 'Name'
-      %th= 'Interview'
-      %th= 'Staff Note'
-      %th= 'Hired?'
+      %th Date Submitted
+      %th Name
+      %th Interview
+      %th Staff Note
+      %th Hired?
   %tbody
     - @records.each do |record|
       %tr
@@ -25,7 +25,7 @@
           = record.staff_note
         %td
           - unless record.interview.nil?
-            - if record.interview.hired == true
+            - if record.interview.hired?
               Yes
             - else
               No -

--- a/app/views/application_records/past_application_records.haml
+++ b/app/views/application_records/past_application_records.haml
@@ -5,6 +5,7 @@
       %th= 'Name'
       %th= 'Interview'
       %th= 'Staff Note'
+      %th= 'Hired?'
   %tbody
     - @records.each do |record|
       %tr
@@ -22,3 +23,10 @@
             = format_date_time record.interview.scheduled
         %td
           = record.staff_note
+        %td
+          - unless record.interview.nil?
+            - if record.interview.hired == true
+              Yes
+            - else
+              No -
+              = record.interview.interview_note

--- a/app/views/application_records/show.haml
+++ b/app/views/application_records/show.haml
@@ -30,7 +30,7 @@ by:
           These notes will be provided to the applicant.
         - else
           These notes will not be provided to the applicant.
-      .action.note_item
+      .note_item
         = submit_tag 'Review application without scheduling interview'
     = form_tag controller: :application_records,
       action: :review,
@@ -48,10 +48,11 @@ by:
           = f.text_field :location,
                          required: true,
                          value: @record.position.default_interview_location
-      .action.note_item= submit_tag 'Review application and schedule interview'
+      .note_item= submit_tag 'Review application and schedule interview'
   - else
-    Application reviewed on
-    = format_date_time @record.updated_at
+    .note_item
+      Application reviewed on:
+      = format_date_time @record.updated_at
     - if @record.staff_note.present?
       .notes.note_item
         Reason for denial:
@@ -76,13 +77,20 @@ by:
           New location:
           = text_field_tag :location, @interview.location,
             required: true, size: 30
-        .action.note_item
+        .note_item
           = submit_tag 'Reschedule interview'
+      %h3 Mark interview as complete:
       = form_tag controller: :interviews,
         action: :complete,
         id: @interview.id do
-        .action.note_item
-          = submit_tag 'Mark interview as completed'
+        .note_item
+          = submit_tag 'Candidate hired',
+            name: 'hired'
+        .field.note_item
+          Reason for rejection:
+          = text_area_tag :interview_note
+        .note_item
+          = submit_tag 'Candidate not hired'
     - else # application is being reviewed for whatever reason
       .note_item
         Interview occurred on

--- a/db/migrate/20151217172608_add_interview_note_to_interviews.rb
+++ b/db/migrate/20151217172608_add_interview_note_to_interviews.rb
@@ -1,0 +1,5 @@
+class AddInterviewNoteToInterviews < ActiveRecord::Migration
+  def change
+    add_column :interviews, :interview_note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151130170123) do
+ActiveRecord::Schema.define(version: 20151217172608) do
 
   create_table "application_drafts", force: :cascade do |t|
     t.integer  "application_template_id", limit: 4
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20151130170123) do
     t.integer  "application_record_id", limit: 4
     t.boolean  "completed"
     t.string   "location",              limit: 255
+    t.string   "interview_note",        limit: 255
   end
 
   create_table "positions", force: :cascade do |t|

--- a/spec/controllers/interviews_controller_spec.rb
+++ b/spec/controllers/interviews_controller_spec.rb
@@ -19,9 +19,36 @@ describe InterviewsController do
       before :each do
         when_current_user_is :staff
       end
-      it 'marks interview as complete' do
-        submit
-        expect(@interview.reload.completed?).to eql true
+      context 'hired button is pressed' do
+        let :submit do
+          post :complete, id: @interview.id, hired: true
+        end
+        it 'marks interview as complete' do
+          submit
+          expect(@interview.reload.completed?).to eql true
+        end
+        it 'markes interview as hired' do
+          submit
+          expect(@interview.reload.hired).to eql true
+        end
+      end
+      context 'not hired button is pressed' do
+        let :submit do
+          post :complete, id: @interview.id, hired: false,
+                          interview_note: 'note'
+        end
+        it 'marks the interview as complete' do
+          submit
+          expect(@interview.reload.completed?).to eql true
+        end
+        it 'marks interview as not hired' do
+          submit
+          expect(@interview.reload.hired).to eql false
+        end
+        it 'adds an interview note to the interview' do
+          submit
+          expect(@interview.reload.interview_note).to eql 'note'
+        end
       end
       context 'with errors' do
         it 'redirects with errors stored in flash' do

--- a/spec/controllers/interviews_controller_spec.rb
+++ b/spec/controllers/interviews_controller_spec.rb
@@ -25,11 +25,11 @@ describe InterviewsController do
         end
         it 'marks interview as complete' do
           submit
-          expect(@interview.reload.completed?).to eql true
+          expect(@interview.reload).to be_completed
         end
         it 'markes interview as hired' do
           submit
-          expect(@interview.reload.hired).to eql true
+          expect(@interview.reload).to be_hired
         end
       end
       context 'not hired button is pressed' do
@@ -39,11 +39,11 @@ describe InterviewsController do
         end
         it 'marks the interview as complete' do
           submit
-          expect(@interview.reload.completed?).to eql true
+          expect(@interview.reload).to be_completed
         end
         it 'marks interview as not hired' do
           submit
-          expect(@interview.reload.hired).to eql false
+          expect(@interview.reload).not_to be_hired
         end
         it 'adds an interview note to the interview' do
           submit

--- a/spec/views/application_records/past_application_record_spec.rb
+++ b/spec/views/application_records/past_application_record_spec.rb
@@ -3,11 +3,11 @@ include RSpecHtmlMatchers
 
 describe 'application_records/past_application_records.haml' do
   before :each do
-    @user1 = create :user, first_name: 'Rick', last_name: 'Cat'
-    @record1 = create :application_record,
-                      user: @user1,
-                      staff_note: 'note'
-    @records = [@record1]
+    @user = create :user, first_name: 'Rick', last_name: 'Cat'
+    @record = create :application_record,
+                     user: @user,
+                     staff_note: 'note'
+    @records = [@record]
     assign :records, @records
   end
   it 'displays a table of application records' do
@@ -16,7 +16,7 @@ describe 'application_records/past_application_records.haml' do
   end
   it 'displays the formatted creation date of the application records' do
     render
-    expect(rendered).to include format_date_time @record1.created_at
+    expect(rendered).to include format_date_time @record.created_at
   end
   it 'displays the proper name of the relevant applicants' do
     render
@@ -30,14 +30,14 @@ describe 'application_records/past_application_records.haml' do
     render
     expect(rendered).to have_tag 'td',
                                  with: { 'data-order' =>
-                                          @record1.created_at.to_i }
+                                          @record.created_at.to_i }
   end
   context 'application record has an upcoming interview' do
     # an interview that has not been completed
     before :each do
       @interview = create :interview,
                           completed: false,
-                          application_record: @record1
+                          application_record: @record
     end
     it 'displays the date of the upcoming interview' do
       render
@@ -47,13 +47,19 @@ describe 'application_records/past_application_records.haml' do
   context 'application record has a completed interview' do
     # an interview that has been completed
     before :each do
+      @note = 'interview note'
       @interview = create :interview,
                           completed: true,
-                          application_record: @record1
+                          application_record: @record,
+                          interview_note: @note
     end
     it 'displays the date of the completed interview' do
       render
       expect(rendered).to include format_date_time @interview.scheduled
+    end
+    it 'displays a note about the interview' do
+      render
+      expect(rendered).to include @note
     end
   end
   context 'application record has no interview' do


### PR DESCRIPTION
Resolves #112 

Here is what the buttons look like:
![screen shot 2015-12-17 at 4 54 55 pm](https://cloud.githubusercontent.com/assets/9645316/11883164/f4b17d3a-a4de-11e5-8c23-123ecea70660.png)

That part of the site is not very pretty in general, so I definitely want to do some styling to make it better, but want that to be its own thing so I just tried to make it look passable for now.

I ended up making another attribute on Interview so people (Don) could make notes about the interview if the person wasn't hired, made two buttons and controller logic to handle them, displayed more in the past application page, and wrote some tests for (I think) everything. As usual, let me know what I can improve upon!
