### PR TITLE
Site texts and app display edit

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -9,6 +9,7 @@ class ApplicationDraftsController < ApplicationController
 
   def edit
     @draft.questions << @draft.new_question
+    @site_text = SiteText.find_by(name: 'markdown explanation')
   end
 
   def new

--- a/app/controllers/site_texts_controller.rb
+++ b/app/controllers/site_texts_controller.rb
@@ -30,11 +30,15 @@ class SiteTextsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def find_site_text
     params.require :id
-    @site_text = SiteText.find params[:id]
+    @site_text = SiteText.find_by(name: params[:id])
+    raise ActiveRecord::RecordNotFound if @site_text.nil?
   end
 
   def site_text_parameters

--- a/app/models/site_text.rb
+++ b/app/models/site_text.rb
@@ -1,3 +1,4 @@
 class SiteText < ActiveRecord::Base
   validates :name, :text, presence: true
+  validates :name, uniqueness: true
 end

--- a/app/views/application_drafts/edit.haml
+++ b/app/views/application_drafts/edit.haml
@@ -1,3 +1,8 @@
+Note: The data type of 'explanation' supports markdown.
+- if @site_text.present?
+  For a quick tutorial, please click
+  = link_to 'here.', site_text_url(@site_text.name) 
+
 %h1.title Editing #{@draft.position.name_and_department}
 #flex_wrapper
   .form_column

--- a/app/views/application_drafts/edit.haml
+++ b/app/views/application_drafts/edit.haml
@@ -1,7 +1,7 @@
 Note: The data type of 'explanation' supports markdown.
 - if @site_text.present?
   For a quick tutorial, please click
-  = link_to 'here.', site_text_url(@site_text.name) 
+  = link_to 'here.', site_text_url(@site_text.name)
 
 %h1.title Editing #{@draft.position.name_and_department}
 #flex_wrapper

--- a/app/views/application_drafts/show.haml
+++ b/app/views/application_drafts/show.haml
@@ -36,10 +36,10 @@
               = r.number_field question.prompt, required: question.required?
             - when 'yes/no'
               Yes
-              = r.radio_button question.prompt, 'yes',
+              = r.radio_button question.prompt, 'Yes',
                 required: question.required?
               No
-              = r.radio_button question.prompt, 'no',
+              = r.radio_button question.prompt, 'No',
                 required: question.required?
             - if question.required?
               %span.ast *

--- a/app/views/application_records/show.haml
+++ b/app/views/application_records/show.haml
@@ -15,7 +15,7 @@ by:
         .heading_item= prompt.upcase
     - elsif data_type == 'explanation'
       .data_row
-        .explanation_item= prompt
+        .explanation_item= render_markdown prompt
     - else
       .data_row
         .prompt_item= prompt

--- a/app/views/site_texts/show.haml
+++ b/app/views/site_texts/show.haml
@@ -1,0 +1,2 @@
+%h1.title= @site_text.name.titleize
+= render_markdown @site_text.text

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,13 +50,13 @@ Rails.application.routes.draw do
   get 'sessions/unauthenticated', to: 'sessions#unauthenticated', as: :unauthenticated_session
   get 'sessions/destroy', to: 'sessions#destroy', as: :destroy_session
 
-  resources :site_texts, only: [:edit, :update] do
+  resources :site_texts, only: [:edit, :show, :update] do
     collection do
       get  :request_new
       post :request_new
     end
     member do
-      post :edit#for previewing changes
+      post :edit # for previewing changes
     end
   end
 

--- a/spec/controllers/site_texts_controller_spec.rb
+++ b/spec/controllers/site_texts_controller_spec.rb
@@ -170,7 +170,7 @@ describe SiteTextsController do
         get :show, id: 'not a name of anything'
       end
       it 'raises RecordNotFound exception' do
-        expect{ submit }.to raise_error ActiveRecord::RecordNotFound
+        expect { submit }.to raise_error ActiveRecord::RecordNotFound
       end
     end
     context 'site text exists' do

--- a/spec/controllers/site_texts_controller_spec.rb
+++ b/spec/controllers/site_texts_controller_spec.rb
@@ -7,7 +7,7 @@ describe SiteTextsController do
     end
     context 'GET' do
       let :submit do
-        get :edit, id: @site_text.id
+        get :edit, id: @site_text.name
       end
       context 'student' do
         it 'does not allow access' do
@@ -32,7 +32,7 @@ describe SiteTextsController do
         @input = 'input'
       end
       let :submit do
-        get :edit, id: @site_text.id, preview_input: @input
+        get :edit, id: @site_text.name, preview_input: @input
       end
       context 'student' do
         it 'does not allow access' do
@@ -59,7 +59,7 @@ describe SiteTextsController do
       @changes = { text: 'new text' }
     end
     let :submit do
-      put :update, id: @site_text.id, site_text: @changes
+      put :update, id: @site_text.name, site_text: @changes
     end
     context 'student' do
       it 'does not allow access' do
@@ -157,6 +157,50 @@ describe SiteTextsController do
       it 'redirects to staff dashboard' do
         submit
         expect(response).to redirect_to staff_dashboard_path
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    context 'site text does not exist' do
+      before :each do
+        when_current_user_is :staff
+      end
+      let :submit do
+        get :show, id: 'not a name of anything'
+      end
+      it 'raises RecordNotFound exception' do
+        expect{ submit }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+    context 'site text exists' do
+      before :each do
+        @site_text = create :site_text
+      end
+      let :submit do
+        get :show, id: @site_text.name
+      end
+      context 'staff' do
+        before :each do
+          when_current_user_is :staff
+        end
+        it 'finds the right site text' do
+          submit
+          expect(assigns.fetch :site_text).to eql @site_text
+        end
+        it 'renders the show page' do
+          submit
+          expect(response).to render_template 'show'
+        end
+      end
+      context 'student' do
+        before :each do
+          when_current_user_is :student
+        end
+        it 'does not allow access' do
+          submit
+          expect(response).to have_http_status :unauthorized
+        end
       end
     end
   end

--- a/spec/factories/site_texts.rb
+++ b/spec/factories/site_texts.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :site_text do
-    name 'text name'
+    sequence(:name) { |n| "Name #{n}" }
     text 'text'
   end
 end


### PR DESCRIPTION
Closes #119 

Application record show page now contains any markdown used in application drafts/template. What the applicant sees is now what we see on the application record display page.

Tests written for new site texts controller logic that will display a 404 not found error when the site text does not exist. Also, if there is no site text, the link to the markdown explanation will not display.