### PR TITLE
Refuse coverage percentage drops

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,9 @@ require 'factory_girl_rails'
 require 'simplecov'
 
 CodeClimate::TestReporter.start if ENV['CI']
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  refuse_coverage_drop
+end
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
This will produce failure messages locally, but the most important
consequence will be Travis builds failing outright.