### PR TITLE
Add DESCRIPTION field to iCal export.

### DIFF
--- a/app/views/interviews/interview.ics.erb
+++ b/app/views/interviews/interview.ics.erb
@@ -5,6 +5,7 @@ TZID:US-Eastern
 METHOD:PUBLISH
 BEGIN:VEVENT
 DTSTART:<%= format_date_time @interview.scheduled, format: :iCal %>
+DESCRIPTION:<%= application_record_url %>
 SUMMARY:<%= @interview.calendar_title %>
 UID:INTERVIEW<%= @interview.id -%>@UMASS_TRANSIT//JOBAPPS
 DTSTAMP:<%= format_date_time DateTime.now, format: :iCal %>

--- a/app/views/interviews/interview.ics.erb
+++ b/app/views/interviews/interview.ics.erb
@@ -5,7 +5,7 @@ TZID:US-Eastern
 METHOD:PUBLISH
 BEGIN:VEVENT
 DTSTART:<%= format_date_time @interview.scheduled, format: :iCal %>
-DESCRIPTION:<%= application_record_url(@interview.application_record_id) %>
+DESCRIPTION:<%= application_record_url(@interview.application_record) %>
 SUMMARY:<%= @interview.calendar_title %>
 UID:INTERVIEW<%= @interview.id -%>@UMASS_TRANSIT//JOBAPPS
 DTSTAMP:<%= format_date_time DateTime.now, format: :iCal %>

--- a/app/views/interviews/interview.ics.erb
+++ b/app/views/interviews/interview.ics.erb
@@ -5,7 +5,7 @@ TZID:US-Eastern
 METHOD:PUBLISH
 BEGIN:VEVENT
 DTSTART:<%= format_date_time @interview.scheduled, format: :iCal %>
-DESCRIPTION:<%= application_record_url %>
+DESCRIPTION:<%= application_record_url(@interview.application_record_id) %>
 SUMMARY:<%= @interview.calendar_title %>
 UID:INTERVIEW<%= @interview.id -%>@UMASS_TRANSIT//JOBAPPS
 DTSTAMP:<%= format_date_time DateTime.now, format: :iCal %>

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 42.98
+    "covered_percent": 99.83
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.83
+    "covered_percent": 42.98
   }
 }

--- a/spec/views/interviews/ical_export_spec.rb
+++ b/spec/views/interviews/ical_export_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+include RSpecHtmlMatchers
+
+describe 'interviews/interview.ics.erb' do
+  before :each do
+    @interview = create :interview
+  end
+  
+  it 'Passes the correct field properties to the ics object' do
+    render
+    @lines = {};
+    rendered.each_line do |line|
+      key, value = line.split ':', 2
+      @lines[key] = value
+    end
+    @lines.each do |key, value|
+      puts key + ':'
+      puts value
+    end
+    expect(@lines['DTSTART']).to eql ((format_date_time @interview.scheduled, format: :iCal) + "\n")
+    expect(@lines['DESCRIPTION']).to eql application_record_url(@interview.application_record_id) + "\n"
+    expect(@lines['SUMMARY']).to eql @interview.calendar_title + "\n"
+    expect(@lines['UID']).to eql 'INTERVIEW' + @interview.id.to_s + "@UMASS_TRANSIT//JOBAPPS\n"
+    expect(@lines['DTSTAMP']).to eql ((format_date_time DateTime.now, format: :iCal) + "\n")
+  end
+end

--- a/spec/views/interviews/ical_export_spec.rb
+++ b/spec/views/interviews/ical_export_spec.rb
@@ -8,19 +8,17 @@ describe 'interviews/interview.ics.erb' do
   
   it 'Passes the correct field properties to the ics object' do
     render
-    @lines = {};
+    @lines = {}
     rendered.each_line do |line|
       key, value = line.split ':', 2
-      @lines[key] = value
+      @lines[key] = value.strip
     end
     @lines.each do |key, value|
-      puts key + ':'
-      puts value
     end
-    expect(@lines['DTSTART']).to eql ((format_date_time @interview.scheduled, format: :iCal) + "\n")
-    expect(@lines['DESCRIPTION']).to eql application_record_url(@interview.application_record_id) + "\n"
-    expect(@lines['SUMMARY']).to eql @interview.calendar_title + "\n"
-    expect(@lines['UID']).to eql 'INTERVIEW' + @interview.id.to_s + "@UMASS_TRANSIT//JOBAPPS\n"
-    expect(@lines['DTSTAMP']).to eql ((format_date_time DateTime.now, format: :iCal) + "\n")
+    expect(@lines['DTSTART']).to eql (format_date_time @interview.scheduled, format: :iCal)
+    expect(@lines['DESCRIPTION']).to eql application_record_url(@interview.application_record_id)
+    expect(@lines['SUMMARY']).to eql @interview.calendar_title
+    expect(@lines['UID']).to eql 'INTERVIEW' + @interview.id.to_s + "@UMASS_TRANSIT//JOBAPPS"
+    expect(@lines['DTSTAMP']).to eql (format_date_time DateTime.now, format: :iCal)
   end
 end


### PR DESCRIPTION
Closed PR #141 in favor of this.  Closes #68.  I added a description to the interview iCal export that contains the absolute url to the ApplicationRecord.  

As @werebus noted in the other PR, we may include more to make the field more helpful.  The interviewee's name is included, so perhaps we can include their email address as well.  #68 said staff asked for a phone number, but jobapps doesn't require a phone number from the interviewee.

There is currently no view test for the iCal export, so I'm going to create it in <code>spec/views/interviews</code> and base it off of <code>spec/views/application_records/csv_export_spec.rb</code>