### PR TITLE
Add custom cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: ./lib/custom_cops/be_for_singleton.rb
+
 AllCops:
   RunRailsCops: true
   Exclude:

--- a/lib/custom_cops/be_for_singleton.rb
+++ b/lib/custom_cops/be_for_singleton.rb
@@ -12,6 +12,13 @@ module RuboCop
                                  int_type?
                                  float_type?)
 
+        def autocorrect(node)
+          lambda do |corrector|
+            matcher = node.child_nodes[1]
+            corrector.replace matcher.loc.selector, 'be'
+          end
+        end
+
         def on_send(node)
           return unless node.method_name == :to
           return unless node.child_nodes.first.method_name == :expect
@@ -20,7 +27,7 @@ module RuboCop
           return unless %i(eq eql).include? matcher.method_name
 
           args = matcher.child_nodes.first
-          if OFFENSE_TYPE_CHECKS.map { |check| args.send check }.any?
+          if OFFENSE_TYPE_CHECKS.find { |check| args.send check }
             add_offense node, :expression, MSG
           end
         end

--- a/lib/custom_cops/be_for_singleton.rb
+++ b/lib/custom_cops/be_for_singleton.rb
@@ -1,5 +1,3 @@
-require 'pry-byebug'
-
 module RuboCop
   module Cop
     module CustomCops

--- a/lib/custom_cops/be_for_singleton.rb
+++ b/lib/custom_cops/be_for_singleton.rb
@@ -19,7 +19,8 @@ module RuboCop
 
         def on_send(node)
           return unless node.method_name == :to
-          return unless node.child_nodes.first.method_name == :expect
+          return unless node.child_nodes &&
+                        node.child_nodes.first.method_name == :expect
 
           matcher = node.child_nodes[1]
           return unless %i(eq eql).include? matcher.method_name

--- a/lib/custom_cops/be_for_singleton.rb
+++ b/lib/custom_cops/be_for_singleton.rb
@@ -1,0 +1,30 @@
+require 'pry-byebug'
+
+module RuboCop
+  module Cop
+    module CustomCops
+      class BeForSingleton < Cop
+        MSG = 'Prefer `be` matcher to `eq` or `eql` for singleton types.'
+
+        OFFENSE_TYPE_CHECKS = %i(true_type?
+                                 false_type?
+                                 nil_type?
+                                 int_type?
+                                 float_type?)
+
+        def on_send(node)
+          return unless node.method_name == :to
+          return unless node.child_nodes.first.method_name == :expect
+
+          matcher = node.child_nodes[1]
+          return unless %i(eq eql).include? matcher.method_name
+
+          args = matcher.child_nodes.first
+          if OFFENSE_TYPE_CHECKS.map { |check| args.send check }.any?
+            add_offense node, :expression, MSG
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -71,7 +71,7 @@ describe ApplicationDraftsController do
         expect { submit }
           .not_to change { @draft.questions.count }
         # Factory draft has 0 questions by default
-        expect(assigns.fetch(:draft).questions.size).to eql 1
+        expect(assigns.fetch(:draft).questions.size).to be 1
       end
       it 'renders the edit template' do
         submit

--- a/spec/controllers/application_records_controller_spec.rb
+++ b/spec/controllers/application_records_controller_spec.rb
@@ -177,7 +177,7 @@ describe ApplicationRecordsController do
         end
         it 'marks record as reviewed' do
           submit
-          expect(@record.reload.reviewed).to eql true
+          expect(@record.reload.reviewed).to be true
         end
         it 'redirects to staff dashboard' do
           submit
@@ -202,7 +202,7 @@ describe ApplicationRecordsController do
         end
         it 'marks record as reviewed' do
           submit
-          expect(@record.reload.reviewed).to eql true
+          expect(@record.reload.reviewed).to be true
         end
         it 'displays application_review message' do
           expect_flash_message :application_review

--- a/spec/lib/application_configuration_spec.rb
+++ b/spec/lib/application_configuration_spec.rb
@@ -8,7 +8,7 @@ describe ApplicationConfiguration do
         expect(CONFIG).to receive(:[]).with(:present_key).and_return true
       end
       it 'returns the value' do
-        expect(configured_value [:present_key]).to eql true
+        expect(configured_value [:present_key]).to be true
       end
     end
     context 'value not present in configuration' do

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -67,8 +67,8 @@ describe ApplicationDraft do
     end
     it 'initializes a new question for the draft with the correct number' do
       expect(call.application_draft).to eql @draft
-      expect(call.number).to eql 4
-      expect(call.new_record?).to eql true
+      expect(call.number).to be 4
+      expect(call.new_record?).to be true
     end
   end
 

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -156,11 +156,11 @@ describe ApplicationRecord do
   describe 'pending?' do
     it 'returns true if record has not been reviewed' do
       record = create :application_record, reviewed: false
-      expect(record.pending?).to eql true
+      expect(record.pending?).to be true
     end
     it 'returns false if record has been reviewed' do
       record = create :application_record, reviewed: true
-      expect(record.pending?).to eql false
+      expect(record.pending?).to be false
     end
   end
 
@@ -257,7 +257,7 @@ describe ApplicationRecord do
                                     ethnicity: 'Klingon',
                                     gender: 'Female'
       end
-      expect(call[:all].count).to eql 1
+      expect(call[:all].count).to be 1
     end
     it 'counts records containing ethnicities not from ethnicity_options' do
       create :application_record, position: @position,

--- a/spec/models/application_template_spec.rb
+++ b/spec/models/application_template_spec.rb
@@ -18,7 +18,7 @@ describe ApplicationTemplate do
                user: @user
       end
       it 'returns false' do
-        expect(call).to eql false
+        expect(call).to be false
       end
     end
     context 'no pre-existing draft' do
@@ -66,12 +66,12 @@ describe ApplicationTemplate do
       @application_template.draft_belonging_to? @user
     end
     it 'returns false if a draft does not exist for the user in question' do
-      expect(call).to eql false
+      expect(call).to be false
     end
     it 'returns true if a draft does exist for the user in question' do
       create :application_draft, user: @user,
                                  application_template: @application_template
-      expect(call).to eql true
+      expect(call).to be true
     end
   end
 end

--- a/spec/models/interview_spec.rb
+++ b/spec/models/interview_spec.rb
@@ -64,11 +64,11 @@ describe Interview do
   describe 'pending?' do
     it 'returns true if interview has not been completed' do
       interview = create :interview, completed: false
-      expect(interview.pending?).to eql true
+      expect(interview.pending?).to be true
     end
     it 'returns false if interview has been completed' do
       interview = create :interview, completed: true
-      expect(interview.pending?).to eql false
+      expect(interview.pending?).to be false
     end
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -57,28 +57,28 @@ describe Question do
 
     describe 'date?' do
       it 'returns true if data type is date' do
-        expect(@date.date?).to eql true
+        expect(@date.date?).to be true
       end
       it 'returns false if data type is not date' do
-        expect(@explanation.date?).to eql false
+        expect(@explanation.date?).to be false
       end
     end
 
     describe 'explanation?' do
       it 'returns true if data type is explanation' do
-        expect(@explanation.explanation?).to eql true
+        expect(@explanation.explanation?).to be true
       end
       it 'returns false if data type is not explanation' do
-        expect(@heading.explanation?).to eql false
+        expect(@heading.explanation?).to be false
       end
     end
 
     describe 'heading?' do
       it 'returns true if data type is heading' do
-        expect(@heading.heading?).to eql true
+        expect(@heading.heading?).to be true
       end
       it 'returns false if data type is not heading' do
-        expect(@date.heading?).to eql false
+        expect(@date.heading?).to be false
       end
     end
   end
@@ -91,14 +91,14 @@ describe Question do
       %w(date text).each do |data_type|
         question = create :question, application_draft: @draft,
                                      data_type: data_type
-        expect(question.takes_placeholder?).to eql true
+        expect(question.takes_placeholder?).to be true
       end
     end
     it 'returns false for explanation, heading, number, or yes/no' do
       %w(explanation heading number yes/no).each do |data_type|
         question = create :question, application_draft: @draft,
                                      data_type: data_type
-        expect(question.takes_placeholder?).to eql false
+        expect(question.takes_placeholder?).to be false
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,11 +22,11 @@ describe User do
   describe 'student?' do
     it 'returns true if user is not staff' do
       user = create :user, staff: false
-      expect(user.student?).to eql true
+      expect(user.student?).to be true
     end
     it 'returns false if user is staff' do
       user = create :user, staff: true
-      expect(user.student?).to eql false
+      expect(user.student?).to be false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'support/redirect_back_matcher'
 
 CodeClimate::TestReporter.start if ENV['CI']
 SimpleCov.start 'rails' do
+  add_filter '/lib/custom_cops'
   refuse_coverage_drop
 end
 


### PR DESCRIPTION
Use `be` matcher rather than `eq` or `eql` for singleton types
(boolean, fixnum, etc).

Has support for autocorrect, which I used here.

Next up: preferring predicate matchers to matching against the return value of a predicate method.