### PR TITLE
Change Travis notification settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ script:
   - bundle exec rake travis
 notifications:
   email:
-    recipients:
-      - programmers@admin.umass.edu
+    on_success: change
+    on_failure: change
+    recipients: programmers@admin.umass.edu


### PR DESCRIPTION
Only notify on status change.

If we don't get an email for this PR's build, then this is probably what
we want.