### PR TITLE
Change Travis email settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ script:
   - bundle exec rake travis
 notifications:
   email:
-    recipients:
-      - programmers@admin.umass.edu
+    on_success: change
+    on_failure: change
+    recipients: programmers@admin.umass.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - bundle exec rake travis
 notifications:
   email:
-    on_success: change
+    on_success: never
     on_failure: change
     recipients: programmers@admin.umass.edu


### PR DESCRIPTION
Never email on success; only email on failure if it's a change (don't send
successive emails for successive failing builds).