### PR TITLE
Expect Flash Message

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 46.55
+    "covered_percent": 99.84
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.84
+    "covered_percent": 46.55
   }
 }

--- a/spec/features/department_creation_spec.rb
+++ b/spec/features/department_creation_spec.rb
@@ -27,9 +27,8 @@ describe 'creating departments' do
     end
 
     it 'gives a flash message' do
+      expect_flash_message(:department_create)
       click_on 'Save changes'
-      expect(page).to have_selector '#message',
-                                    text: 'Department has been created.'
     end
   end
 

--- a/spec/features/department_deletion_spec.rb
+++ b/spec/features/department_deletion_spec.rb
@@ -22,7 +22,7 @@ describe 'deleting users' do
   it 'gives a flash message' do
     expect_flash_message(:department_destroy)
     click_on "Remove #{dept.name}"
-    #expect(page).to have_selector '#message',
-     #                             text: 'Department has been deleted.'
+    # expect(page).to have_selector '#message',
+    #                             text: 'Department has been deleted.'
   end
 end

--- a/spec/features/department_deletion_spec.rb
+++ b/spec/features/department_deletion_spec.rb
@@ -20,8 +20,9 @@ describe 'deleting users' do
   end
 
   it 'gives a flash message' do
+    expect_flash_message(:department_destroy)
     click_on "Remove #{dept.name}"
-    expect(page).to have_selector '#message',
-                                  text: 'Department has been deleted.'
+    #expect(page).to have_selector '#message',
+     #                             text: 'Department has been deleted.'
   end
 end

--- a/spec/features/department_deletion_spec.rb
+++ b/spec/features/department_deletion_spec.rb
@@ -22,7 +22,5 @@ describe 'deleting users' do
   it 'gives a flash message' do
     expect_flash_message(:department_destroy)
     click_on "Remove #{dept.name}"
-    # expect(page).to have_selector '#message',
-    #                             text: 'Department has been deleted.'
   end
 end

--- a/spec/features/department_edit_spec.rb
+++ b/spec/features/department_edit_spec.rb
@@ -28,9 +28,8 @@ describe 'editing departments' do
     end
 
     it 'gives a flash message' do
+      expect_flash_message(:department_update)
       click_on 'Save changes'
-      expect(page).to have_selector '#message',
-                                    text: 'Department has been updated.'
     end
   end
 

--- a/spec/features/position_creation_spec.rb
+++ b/spec/features/position_creation_spec.rb
@@ -28,9 +28,8 @@ describe 'creating new positions' do
       expect(page.current_url).to eql staff_dashboard_url
     end
     it 'renders a flash message' do
+      expect_flash_message(:position_create)
       click_on 'Save changes'
-      expect(page).to have_selector '#message',
-                                    text: 'Position has been created.'
     end
   end
 

--- a/spec/features/position_deletion_spec.rb
+++ b/spec/features/position_deletion_spec.rb
@@ -27,7 +27,7 @@ describe 'deleting a position' do
     expect(page.current_url).to eql staff_dashboard_url
   end
   it 'renders a positive flash message' do
+    expect_flash_message(:position_destroy)
     delete
-    expect(page).to have_selector '#message', text: 'Position has been deleted.'
   end
 end

--- a/spec/features/position_edit_spec.rb
+++ b/spec/features/position_edit_spec.rb
@@ -27,9 +27,8 @@ describe 'editing positions' do
       expect(page.current_url).to eql staff_dashboard_url
     end
     it 'renders a positive flash message' do
+      expect_flash_message(:position_update)
       save
-      expect(page).to have_selector '#message',
-                                    text: 'Position has been updated'
     end
   end
 

--- a/spec/features/user_creation_spec.rb
+++ b/spec/features/user_creation_spec.rb
@@ -25,8 +25,8 @@ describe 'creating users' do
         .to change { User.count }.by 1
     end
     it 'has a flash message' do
+      expect_flash_message(:user_create)
       click_on 'Save changes'
-      expect(page).to have_selector '#message', text: 'User has been created.'
     end
   end
 

--- a/spec/features/user_deletion_spec.rb
+++ b/spec/features/user_deletion_spec.rb
@@ -19,7 +19,7 @@ describe 'deleting users' do
   end
 
   it 'has a flash message' do
+    expect_flash_message(:user_destroy)
     click_on "Remove #{@user.full_name}"
-    expect(page).to have_selector '#message', text: 'User has been removed.'
   end
 end

--- a/spec/features/user_edit_spec.rb
+++ b/spec/features/user_edit_spec.rb
@@ -29,8 +29,8 @@ describe 'edit users' do
     end
 
     it 'gives a flash message' do
+      expect_flash_message(:user_update)
       click_on 'Save changes'
-      expect(page).to have_selector '#message', text: 'User has been updated.'
     end
   end
 


### PR DESCRIPTION
Closes #192.  

Updated all integration tests to use the spec_helper method ```expect_flash_message``` for...well...expecting flash messages.  

Note that error messages remain unchanged, because they are rendered by a private ApplicationController method called ```show_errors```, and figuring out how to test for it has been determined to be out of the scope of this issue by @dfaulken.