### PR TITLE
Configurable EEO Requests

### DIFF
--- a/app/controllers/application_templates_controller.rb
+++ b/app/controllers/application_templates_controller.rb
@@ -22,6 +22,16 @@ class ApplicationTemplatesController < ApplicationController
     end
     redirect_to :back
   end
+  
+  def toggle_eeo_enabled
+    @template.toggle! :eeo_enabled
+    msg = 'You have enabled EEO data requests on your application.'
+    if !@template.eeo_enabled 
+      msg = 'You have disabled EEO data requests on your application.'
+    end
+    show_message :active_application, default: msg
+    redirect_to :back
+  end
 
   private
 

--- a/app/views/application_drafts/edit.haml
+++ b/app/views/application_drafts/edit.haml
@@ -3,6 +3,21 @@
   - if @site_text.present?
     For a quick tutorial, please click
     = link_to 'here.', site_text_url(@site_text.name)
+    
+- if @draft.application_template.eeo_enabled?
+  .note_item
+    This application requests equal employment opportunity (EEO) data from applicants.
+    Click below to disable these requests.
+    .actions
+    = button_to 'Deactivate EEO',
+        toggle_eeo_enabled_application_url(@draft.application_template)
+- else
+  .note_item
+    This application doesn't request equal employment opportunity (EEO) data from applicants.
+    Click below to enable these requests.
+    .actions
+    = button_to 'Activate EEO',
+        toggle_eeo_enabled_application_url(@draft.application_template)
 
 - if @draft.application_template.active?
   .note_item

--- a/app/views/application_drafts/show.haml
+++ b/app/views/application_drafts/show.haml
@@ -47,23 +47,24 @@
                 required: question.required?
             - if question.required?
               %span.ast *
-      .heading Voluntary Equal Employment Opportunity Information
-      .explanation
-        The University of Massachusetts and the Pioneer Valley
-        Transit Authority are equal opportunity employers. To help
-        us ensure that we are complying with EEO policies, please supply
-        the information requested below.
-      .field
-        .label
-          Please select the ethnic group with which you most closely identify:
-        = select_tag :ethnicity,
-          options_for_select(ApplicationRecord::ETHNICITY_OPTIONS),
-          include_blank: 'Prefer not to answer'
-      .field
-        .label Please select the gender with which you most closely identify:
-        = select_tag :gender,
-          options_for_select(ApplicationRecord::GENDER_OPTIONS),
-          include_blank: 'Prefer not to answer'
+      - if @draft.application_template.eeo_enabled
+        .heading Voluntary Equal Employment Opportunity Information
+        .explanation
+          The University of Massachusetts and the Pioneer Valley
+          Transit Authority are equal opportunity employers. To help
+          us ensure that we are complying with EEO policies, please supply
+          the information requested below.
+        .field
+          .label
+            Please select the ethnic group with which you most closely identify:
+          = select_tag :ethnicity,
+            options_for_select(ApplicationRecord::ETHNICITY_OPTIONS),
+            include_blank: 'Prefer not to answer'
+        .field
+          .label Please select the gender with which you most closely identify:
+          = select_tag :gender,
+            options_for_select(ApplicationRecord::GENDER_OPTIONS),
+            include_blank: 'Prefer not to answer'
     .actions= submit_tag 'Submit application', disabled: true
 
 .form

--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -66,21 +66,22 @@
           = r.hidden_field question.unique_data_type_name,
             value: question.data_type
     = hidden_field_tag :position_id, @template.position_id
-    .heading Voluntary Equal Employment Opportunity Information
-    .explanation
-      The University of Massachusetts and the Pioneer Valley
-      Transit Authority are equal opportunity employers. To help
-      us insure that we are complying with EEO policies, please supply
-      the information requested below.
-    .field
-      .label
-        Please select the ethnic group with which you most closely identify:
-      = select_tag :ethnicity,
-        options_for_select(ApplicationRecord::ETHNICITY_OPTIONS),
-        include_blank: 'Prefer not to answer'
-    .field
-      .label Please select the gender with which you most closely identify:
-      = select_tag :gender,
-        options_for_select(ApplicationRecord::GENDER_OPTIONS),
-        include_blank: 'Prefer not to answer'
+    - if @template.eeo_enabled
+      .heading Voluntary Equal Employment Opportunity Information
+      .explanation
+        The University of Massachusetts and the Pioneer Valley
+        Transit Authority are equal opportunity employers. To help
+        us insure that we are complying with EEO policies, please supply
+        the information requested below.
+      .field
+        .label
+          Please select the ethnic group with which you most closely identify:
+        = select_tag :ethnicity,
+          options_for_select(ApplicationRecord::ETHNICITY_OPTIONS),
+          include_blank: 'Prefer not to answer'
+      .field
+        .label Please select the gender with which you most closely identify:
+        = select_tag :gender,
+          options_for_select(ApplicationRecord::GENDER_OPTIONS),
+          include_blank: 'Prefer not to answer'
     .actions= submit_tag 'Submit application' unless @current_user.try :staff?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :application_templates, as: :applications, path: :applications, only: [:new, :show] do
     member do
       post :toggle_active
+      post :toggle_eeo_enabled
     end
   end
 

--- a/db/migrate/20160224170941_add_eeo_enabled_to_application_templates.rb
+++ b/db/migrate/20160224170941_add_eeo_enabled_to_application_templates.rb
@@ -1,0 +1,5 @@
+class AddEeoEnabledToApplicationTemplates < ActiveRecord::Migration
+  def change
+    add_column :application_templates, :eeo_enabled, :string, default: true
+  end
+end

--- a/db/migrate/20160224210657_add_eeo_enabled_to_application_templates.rb
+++ b/db/migrate/20160224210657_add_eeo_enabled_to_application_templates.rb
@@ -1,5 +1,5 @@
 class AddEeoEnabledToApplicationTemplates < ActiveRecord::Migration
   def change
-    add_column :application_templates, :eeo_enabled, :string, default: true
+    add_column :application_templates, :eeo_enabled, :boolean, default: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160217184845) do
+ActiveRecord::Schema.define(version: 20160224210657) do
 
   create_table "application_drafts", force: :cascade do |t|
     t.integer  "application_template_id", limit: 4
@@ -38,8 +38,8 @@ ActiveRecord::Schema.define(version: 20160217184845) do
     t.integer  "position_id", limit: 4
     t.boolean  "visible",                 default: true
     t.boolean  "active",                  default: true
-    t.boolean  "eeo_enabled",             default: true
     t.string   "slug",        limit: 255
+    t.boolean  "eeo_enabled",             default: true
   end
 
   create_table "departments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160209223913) do
+ActiveRecord::Schema.define(version: 20160217184845) do
 
   create_table "application_drafts", force: :cascade do |t|
     t.integer  "application_template_id", limit: 4
@@ -36,7 +36,9 @@ ActiveRecord::Schema.define(version: 20160209223913) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "position_id", limit: 4
-    t.boolean  "active"
+    t.boolean  "visible",                 default: true
+    t.boolean  "active",                  default: true
+    t.boolean  "eeo_enabled",             default: true
     t.string   "slug",        limit: 255
   end
 


### PR DESCRIPTION
Closes #189.  Includes functionality similar to #133:

- When editing Drafts, adds a button to enable or disable EEO questions on the application

- When previewing a Draft, conditionally displays EEO questions

- When viewing a Template, conditionally displays EEO questions.

Added a migration for a new column in `ApplicationTemplate`: a `boolean` called `eeo_enabled`, which defaults to `true`.

Added a controller action `toggle_eeo_enabled` to `application_templates_controller`.  Controller test forthcoming.

One question before this gets merged (perhaps for @Anbranin): in the HAML, I used the same tags as you did in #189 to display the buttons, but they look VASTLY different (in terms of style).  Any idea why?