### PR TITLE
Configurable hiring text

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -5,4 +5,8 @@ class Department < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
 
   default_scope { order :name }
+
+  def to_key
+    name.underscore.gsub(' ','_').to_sym
+  end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -13,4 +13,8 @@ class Position < ActiveRecord::Base
   def name_and_department
     "#{name} (#{department.name})"
   end
+
+  def to_key
+    name.underscore.gsub(' ','_').to_sym
+  end
 end

--- a/app/views/dashboard/student.haml
+++ b/app/views/dashboard/student.haml
@@ -25,5 +25,6 @@
           application_path(position.application_template)
       - else
         %li
-          We are not currently hiring for the position,
-          #{position.name}. Please check back.
+          = configured_value([:deactivated_application,
+            department.to_key, position.to_key],
+            default: "Applications are currently unavailable for #{position.name}")

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -6,6 +6,16 @@
 # This value will populate landing pages, page titles, and email templates.
 organization_name: 'UMass Transit'
 
+deactivated_application:
+# This is the text shown to applicants when the application is inactive.
+# Follow the template like so. Make sure all names are underscored and
+# lowercased.
+  special_transportation:
+    van_driver: 'We are not currently hiring van drivers'
+  bus:
+    operator: 'We are not currently hiring bus drivers'
+    cleaner: 'We do not currently need any bus cleaners'
+
 email:
   # This value determines where site emails will be sent from (e.g. noreply).
   default_from: 'transit-it@admin.umass.edu'


### PR DESCRIPTION
"Not hiring right now" text can now be configured.
For the life of me, though, I cannot seem to find an elegant way to lessen the line length
of the default configurable message text in the view. It is 3 characters over 80!


closes #188 