### PR TITLE
Add the ability to reload data from older applications (of the same type)

### DIFF
--- a/app/assets/stylesheets/application_templates/show.scss
+++ b/app/assets/stylesheets/application_templates/show.scss
@@ -1,0 +1,9 @@
+#old_application_block {
+  padding-top: 10px;
+  #subtitle {
+    padding-bottom: 8px;
+  }
+  .load_column {
+    padding-left: 15px;
+  }
+}

--- a/app/controllers/application_templates_controller.rb
+++ b/app/controllers/application_templates_controller.rb
@@ -10,6 +10,12 @@ class ApplicationTemplatesController < ApplicationController
   end
 
   def show
+    @old_applications = @current_user.try(:old_applications,
+                                          @template.position_id)
+    @old_data = {}
+    if params[:load_id]
+      @old_data = ApplicationRecord.find(params[:load_id]).try :questions_hash || nil
+    end
   end
 
   def toggle_active

--- a/app/controllers/application_templates_controller.rb
+++ b/app/controllers/application_templates_controller.rb
@@ -14,7 +14,7 @@ class ApplicationTemplatesController < ApplicationController
                                           @template.position_id)
     @old_data = {}
     if params[:load_id]
-      @old_data = ApplicationRecord.find(params[:load_id]).try :questions_hash || nil
+      @old_data = ApplicationRecord.find(params[:load_id]).try :questions_hash || {}
     end
   end
 

--- a/app/controllers/application_templates_controller.rb
+++ b/app/controllers/application_templates_controller.rb
@@ -11,7 +11,7 @@ class ApplicationTemplatesController < ApplicationController
 
   def show
     @old_applications = @current_user.try(:old_applications,
-                                          @template.position_id)
+                                          @template)
     @old_data = {}
     if params[:load_id]
       @old_data = ApplicationRecord.find(params[:load_id]).try :questions_hash || {}

--- a/app/controllers/application_templates_controller.rb
+++ b/app/controllers/application_templates_controller.rb
@@ -14,7 +14,8 @@ class ApplicationTemplatesController < ApplicationController
                                           @template)
     @old_data = {}
     if params[:load_id]
-      @old_data = ApplicationRecord.find(params[:load_id]).try :questions_hash || {}
+      @old_data = ApplicationRecord.find(params[:load_id])
+                                   .try :questions_hash || {}
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,13 +9,20 @@ module ApplicationHelper
   def parse_application_data(data)
     questions = []
     data.each do |k, v|
-      match_data = k.match(/^(prompt|response|data_type)_(\d+)$/)
+      match_data = k.match(/^(prompt|response|data_type)?_?(\d+)$/)
       next unless match_data.present?
-      input_type, number = match_data.captures
-      questions[number.to_i] ||= []
-      input_types = %w(prompt response data_type)
-      index = input_types.index input_type
-      questions[number.to_i][index] = v
+      captures = match_data.captures.select{|c| !c.nil? }
+      if captures.length == 2
+        input_type, number = match_data.captures
+        questions[number.to_i] ||= []
+        input_types = %w(prompt response data_type)
+        index = input_types.index input_type
+        questions[number.to_i][index] = v
+      elsif captures.length == 1
+        q_id, number = v.split('-')
+        questions[number.to_i] ||= []
+        questions[number.to_i][3] = q_id.to_i + 1
+      end
     end
     questions
   end
@@ -28,6 +35,14 @@ module ApplicationHelper
 
   def should_show_denied_applications?
     configured_value [:on_application_denial, :notify_applicant], default: true
+  end
+
+  def should_allow_resubmission?
+    configured_value [:on_application_denial, :allow_resubmission], default: true
+  end
+
+  def should_allow_form_refilling?
+    configured_value [:on_application_denial, :fill_form_with_old], default: true
   end
 
   def text(name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,20 +9,24 @@ module ApplicationHelper
   def parse_application_data(data)
     questions = []
     data.each do |k, v|
-      match_data = k.match(/^(prompt|response|data_type)?_?(\d+)$/)
+      match_data = k.match(/^(prompt|response|data_type)?_?(\d+)$/) ||
+                   v.match(/^(\d+)\-(\d+)$/)
       next unless match_data.present?
-      captures = match_data.captures.select{|c| !c.nil? }
-      if captures.length == 2
-        input_type, number = match_data.captures
-        questions[number.to_i] ||= []
-        input_types = %w(prompt response data_type)
-        index = input_types.index input_type
-        questions[number.to_i][index] = v
-      elsif captures.length == 1
-        q_id, number = v.split('-')
-        questions[number.to_i] ||= []
-        questions[number.to_i][3] = q_id.to_i + 1
-      end
+
+      input_type, number = match_data.captures
+      questions[number.to_i] ||= []
+      input_types = %w(prompt response data_type)
+
+      # Because we cannot match "all numeric values" for input_type, we
+      # must use a || 3 since if you .index(\d+) it will return nil here
+      # which the || 3 will catch.
+      index = input_types.index(input_type) || 3
+      questions[number.to_i][index] =
+        if index == 3 # a.k.a. If it is a numeric number (Q_ID)
+          input_type.to_i + 1
+        else
+          v
+        end
     end
     questions
   end
@@ -38,11 +42,13 @@ module ApplicationHelper
   end
 
   def should_allow_resubmission?
-    configured_value [:on_application_denial, :allow_resubmission], default: true
+    configured_value [:on_application_denial, :allow_resubmission],
+                     default: true
   end
 
   def should_allow_form_refilling?
-    configured_value [:on_application_denial, :fill_form_with_old], default: true
+    configured_value [:on_application_denial, :fill_form_with_old],
+                     default: true
   end
 
   def text(name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,8 +9,9 @@ module ApplicationHelper
   def parse_application_data(data)
     questions = []
     data.each do |k, v|
-      match_data = k.match(/^(prompt|response|data_type)?_?(\d+)$/) ||
-                   v.match(/^(\d+)\-(\d+)$/)
+      match_data = v.match(/^(\d+)\-(\d+)$/) ||
+                   k.match(/^(prompt|response|data_type)_(\d+)$/)
+
       next unless match_data.present?
 
       input_type, number = match_data.captures

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -56,7 +56,7 @@ class ApplicationRecord < ActiveRecord::Base
       # The four element sub-arrays use the format
       # [prompt, response, data_type, question_id]
       # So the desired indices are 3 and 1 for a
-      # Question_ID -> Response hash
+      # question_id -> response hash
 
       qid_index = 3
       response_index = 1

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -50,9 +50,21 @@ class ApplicationRecord < ActiveRecord::Base
     update(data: data << [prompt, response])
     self
   end
-  
+
   def questions_hash
-    data.map{|arr| [arr[3], arr[1]]}.select{|arr| [arr[0], arr[1]].all?}.to_h
+    data.map do |array4| # Sub-arrays of four elements
+      # The four element sub-arrays use the format
+      # [prompt, response, data_type, question_id]
+      # So the desired indices are 3 and 1 for a
+      # Question_ID -> Response hash
+
+      qid_index, response_index = 3, 1
+      [array4[qid_index], array4[response_index]]
+    end.select do |array2| # New sub-arrays of two elements
+      # Make sure no element is nil (i.e. no response)
+
+      array2.all?
+    end.to_h # Cast it to a hash for easy referencing in the view
   end
 
   def deny_with(staff_note)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -50,6 +50,10 @@ class ApplicationRecord < ActiveRecord::Base
     update(data: data << [prompt, response])
     self
   end
+  
+  def questions_hash
+    data.map{|arr| [arr[3], arr[1]]}.select{|arr| [arr[0], arr[1]].all?}.to_h
+  end
 
   def deny_with(staff_note)
     update staff_note: staff_note

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -58,13 +58,11 @@ class ApplicationRecord < ActiveRecord::Base
       # So the desired indices are 3 and 1 for a
       # Question_ID -> Response hash
 
-      qid_index, response_index = 3, 1
+      qid_index = 3
+      response_index = 1
       [array4[qid_index], array4[response_index]]
-    end.select do |array2| # New sub-arrays of two elements
-      # Make sure no element is nil (i.e. no response)
-
-      array2.all?
-    end.to_h # Cast it to a hash for easy referencing in the view
+    end
+        .select(&:all?).to_h
   end
 
   def deny_with(staff_note)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,4 +30,8 @@ class User < ActiveRecord::Base
   def student?
     !staff?
   end
+
+  def old_applications(position_id)
+    application_records.where(position_id: position_id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ActiveRecord::Base
     !staff?
   end
 
-  def old_applications(position_id)
-    application_records.where(position_id: position_id)
+  def old_applications(position)
+    application_records.where(position_id: position.id)
   end
 end

--- a/app/views/application_records/show.haml
+++ b/app/views/application_records/show.haml
@@ -9,7 +9,7 @@ by:
   .data_row
     %h3.prompt_item Question
     %h3.response_item Response
-  - @record.data.each do |prompt, response, data_type|
+  - @record.data.each do |prompt, response, data_type, question_id|
     - if data_type == 'heading'
       .data_row
         .heading_item= prompt.upcase
@@ -119,7 +119,7 @@ by:
       = @interview.information
     - else
       Your application has been denied.
-      - if configured_value([:on_application_denial, :provide_reason],
+      - if configured_value([:on_application_denial, :notify_of_reason],
         default: true)
         Reason:
         = @record.staff_note

--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -14,13 +14,27 @@
       = button_to 'Activate application',
           toggle_active_application_url(@template)
 
-- if @current_user.try(:staff?) || @template.active?
+- if @template.active?
   .form
     %h1.title Application for #{@template.position.name_and_department}
     %strong
       Fields marked with an asterisk (
       %span.ast *
       ) are required.
+    - if should_allow_form_refilling? && @old_applications.present?
+      .row#old_application_block
+        .col-md-8.col-md-offset-2#subtitle
+          You have some old applications you can take responses from!
+        %table.col-md-8.col-md-offset-2
+          %tr
+            %th
+              Submitted
+          - @old_applications.each do |app|
+            %tr
+              %td
+                = format_date_time app.created_at
+              %td.load_column
+                = link_to 'Load reponses', url_for(params.merge(:load_id => app.id))
     = form_tag controller: :application_records, action: :create do
       = fields_for :user do |u|
         .field
@@ -28,53 +42,69 @@
           .explanation You will be able to log in and review your application.
         - [:first_name, :last_name, :email].each do |field|
           .field
-            .label= u.label field
-            = u.text_field field, size: 50, required: true,
-              value: @current_user.try(field)
-            %span.ast *
+            .row
+              .col-md-6
+                .label= u.label field
+              .col-md-6
+                = u.text_field field, size: 50, required: true,
+                  value: @current_user.try(field)
+                %span.ast *
       = fields_for :data do |r|
         - @template.questions.each do |question|
           .field
             - if question.explanation?
               .explanation= render_markdown question.prompt
             - elsif question.heading?
-              %h3.heading= question.prompt
+              %h3.heading
+                = question.prompt
             - else
-              .label= r.label question.prompt, question.prompt
-              - case question.data_type
-              - when 'phone-number'
-                = r.text_field question.prompt, required: question.required?,
-                  class: 'phone', size: 20, placeholder: '(XXX) XXX-XXXX'
-              - when 'long-text'
-                = r.text_area question.unique_name,
-                  required: question.required?,
-                  size: '50x5'
-              - when 'text'
-                = r.text_field question.unique_name,
-                  required: question.required?,
-                  size: 50
-              - when 'date'
-                = r.text_field question.unique_name,
-                  required: question.required?,
-                  class: 'datepicker',
-                  placeholder: 'Click here to select date...',
-                  size: 40
-              - when 'number'
-                = r.number_field question.unique_name,
-                  required: question.required?
-              - when 'yes/no'
-                Yes
-                = r.radio_button question.unique_name, 'Yes',
-                  required: question.required?
-                No
-                = r.radio_button question.unique_name, 'No',
-                  required: question.required?
-              - if question.required?
-                %span.ast *
+              .form-group.row
+                .col-md-6.text-right
+                  .label= r.label question.prompt, question.prompt
+                .col-md-6
+                  - case question.data_type
+                  - when 'phone-number'
+                    = r.text_field question.prompt, required: question.required?,
+                      class: 'phone', size: 20, placeholder: '(XXX) XXX-XXXX',
+                      value: @old_data[question.id] || ""
+                  - when 'long-text'
+                    = r.text_area question.unique_name,
+                      required: question.required?,
+                      size: '50x5',
+                      value: @old_data[question.id] || ""
+                  - when 'text'
+                    = r.text_field question.unique_name,
+                      required: question.required?,
+                      size: 50,
+                      value: @old_data[question.id] || ""
+                  - when 'date'
+                    = r.text_field question.unique_name,
+                      required: question.required?,
+                      class: 'datepicker',
+                      placeholder: 'Click here to select date...',
+                      size: 40,
+                      value: @old_data[question.id] || ""
+                  - when 'number'
+                    = r.number_field question.unique_name,
+                      required: question.required?,
+                      value: (@old_data[question.id] || "").to_i
+                  - when 'yes/no'
+                    Yes
+                    = r.radio_button question.unique_name, 'Yes',
+                      required: question.required?,
+                      checked: @old_data[question.id] == 'Yes'
+                    No
+                    = r.radio_button question.unique_name, 'No',
+                      required: question.required?,
+                      checked: @old_data[question.id] == 'No'
+                  - if question.required?
+                    %span.ast *
             = r.hidden_field question.unique_prompt_name,
               value: question.prompt
             = r.hidden_field question.unique_data_type_name,
               value: question.data_type
+            = r.hidden_field question.id,
+              value: "#{question.id}-#{question.number}"
       = hidden_field_tag :position_id, @template.position_id
       - if @template.eeo_enabled?
         .heading Voluntary Equal Employment Opportunity Information

--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -14,7 +14,7 @@
       = button_to 'Activate application',
           toggle_active_application_url(@template)
 
-- if @template.active?
+- if @current_user.try(:staff?) || @template.active?
   .form
     %h1.title Application for #{@template.position.name_and_department}
     %strong
@@ -34,7 +34,7 @@
               %td
                 = format_date_time app.created_at
               %td.load_column
-                = link_to 'Load reponses', url_for(params.merge(:load_id => app.id))
+                = link_to 'Load reponses', application_path(@template, load_id: app.id)
     = form_tag controller: :application_records, action: :create do
       = fields_for :user do |u|
         .field
@@ -55,8 +55,7 @@
             - if question.explanation?
               .explanation= render_markdown question.prompt
             - elsif question.heading?
-              %h3.heading
-                = question.prompt
+              %h3.heading= question.prompt
             - else
               .form-group.row
                 .col-md-6.text-right

--- a/app/views/dashboard/student.haml
+++ b/app/views/dashboard/student.haml
@@ -20,9 +20,19 @@
         - should_show = application.pending? || should_show_denied_applications?
       - if app_submitted && should_show
         %li= link_to "Review your application for #{position.name}", application
-      - elsif position.application_template.try(:active?)
-        %li= link_to "Submit application for #{position.name}",
-          application_path(position.application_template)
+      - if position.application_template.try(:active?)
+        - if app_submitted
+          - if should_allow_resubmission?
+            -if application.reviewed
+              %li= link_to "Resubmit application for #{position.name}",
+                application_path(position.application_template)
+            - else
+              Your application has been reviewed yet.
+          - else
+            You are not allowed to resubmit this application.
+        -else
+          %li= link_to "Submit application for #{position.name}",
+            application_path(position.application_template)
       - else
         %li
           = position.configured_not_hiring_text

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -35,7 +35,12 @@ on_application_denial:
   # For instance, you may wish to provide feedback on steps applicants
   # could take in order to become eligible for the position in the future.
   notify_of_reason: true
-
+  # Whether or not an applicant will be allowed to resubmit an application
+  # to a declined application
+  allow_resubmission: true
+  # Whether or not the applicant will be allowed to refill in new applications
+  # with data from past ones.
+  fill_form_with_old: true
 
 # MESSAGE KEYS
 # Many site messages which are shown to your users are configurable -

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -38,8 +38,9 @@ on_application_denial:
   # Whether or not an applicant will be allowed to resubmit an application
   # to a declined application
   allow_resubmission: true
-  # Whether or not the applicant will be allowed to refill in new applications
-  # with data from past ones.
+  # Whether or not an applicant will be allowed to resubmit an application for
+  # a particular position when they have previously had an application for that
+  # position denied
   fill_form_with_old: true
 
 # MESSAGE KEYS

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -35,12 +35,12 @@ on_application_denial:
   # For instance, you may wish to provide feedback on steps applicants
   # could take in order to become eligible for the position in the future.
   notify_of_reason: true
-  # Whether or not an applicant will be allowed to resubmit an application
-  # to a declined application
-  allow_resubmission: true
   # Whether or not an applicant will be allowed to resubmit an application for
   # a particular position when they have previously had an application for that
   # position denied
+  allow_resubmission: true
+  # Whether or not the applicant will be allowed to refill in new applications
+  # with data from past ones.
   fill_form_with_old: true
 
 # MESSAGE KEYS

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.84
+    "covered_percent": 100.0
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.36
+    "covered_percent": 99.84
   }
 }

--- a/lib/application_configuration.rb
+++ b/lib/application_configuration.rb
@@ -7,7 +7,13 @@ module ApplicationConfiguration
   # configured.
   def configured_value(config_path, options = {})
     value = CONFIG.dig(*config_path)
-    if value.present? then value
+
+    # This is a peculiar situation because value will return {}
+    # on failed queries. However, it is entirely possible that
+    # a query will yield false (as a configured value), so we cannot
+    # use standard .present? or .blank?. We also cannot use .empty?
+    # because TrueClass and FalseClass do not support it
+    if value != {} then value
     elsif options[:default].present? then options[:default]
     else
       raise ArgumentError,

--- a/spec/controllers/application_templates_controller_spec.rb
+++ b/spec/controllers/application_templates_controller_spec.rb
@@ -49,6 +49,17 @@ describe ApplicationTemplatesController do
         get :show, id: @template.slug
       end
 
+      let :submit_with_load_id do
+        get :show, id: @template.slug, load_id: @record.id
+      end
+
+      context 'with a record to preload from' do
+        it 'gets the correct question hash' do
+          when_current_user_is :student
+          submit_with_load_id
+          expect(assigns(:old_data)).to eq(@record.questions_hash)
+        end
+      end
       context 'no user' do
         it 'allows access' do
           when_current_user_is nil

--- a/spec/controllers/application_templates_controller_spec.rb
+++ b/spec/controllers/application_templates_controller_spec.rb
@@ -41,11 +41,14 @@ describe ApplicationTemplatesController do
       department = create :department, name: 'Bus'
       position = create :position, name: 'Operator', department: department
       @template = create :application_template, position: position
+      @record = create :application_record,
+                       data: [['a question', 'an answer', 'data type', 1]]
     end
     context 'using specific route' do
       let :submit do
         get :show, id: @template.slug
       end
+
       context 'no user' do
         it 'allows access' do
           when_current_user_is nil

--- a/spec/controllers/concerns/configurable_messages_spec.rb
+++ b/spec/controllers/concerns/configurable_messages_spec.rb
@@ -2,20 +2,30 @@ require 'rails_helper'
 include ConfigurableMessages
 
 describe ConfigurableMessages do
-  describe 'show_message' do
-    let(:call) { show_message :cool_message, default: "I'm cool" }
-    before :each do
-      expect_any_instance_of(ApplicationConfiguration)
-        .to receive(:configured_value)
-        .with([:messages, :cool_message], default: "I'm cool")
-        .and_return 'a retrieved value'
+  context 'valid calls' do
+    describe 'show_message' do
+      let(:call) { show_message :cool_message, default: "I'm cool" }
+      before :each do
+        expect_any_instance_of(ApplicationConfiguration)
+          .to receive(:configured_value)
+          .with([:messages, :cool_message], default: "I'm cool")
+          .and_return 'a retrieved value'
+      end
+      it 'calls ApplicationConfiguration#configured_value as expected' do
+        call
+      end
+      it 'stores the returned value in the flash' do
+        call
+        expect(flash[:message]).to eql 'a retrieved value'
+      end
     end
-    it 'calls ApplicationConfiguration#configured_value as expected' do
-      call
+  end
+  context 'invalid calls' do
+    let(:call) do
+      check_message_default(:user_create, default: 'not the actual default')
     end
-    it 'stores the returned value in the flash' do
-      call
-      expect(flash[:message]).to eql 'a retrieved value'
+    it 'raises an error with invalid parameters' do
+      expect { call }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/features/student_dashboard_view_spec.rb
+++ b/spec/features/student_dashboard_view_spec.rb
@@ -60,7 +60,7 @@ describe 'viewing the dashboard as a student' do
               .to receive :configured_value
             allow_any_instance_of(ApplicationConfiguration)
               .to receive(:configured_value)
-              .with([:on_application_denial, :provide_reason], anything)
+              .with([:on_application_denial, :notify_of_reason], anything)
               .and_return false
           end
           it 'has link to see denied app, without text of denial reason' do
@@ -78,7 +78,7 @@ describe 'viewing the dashboard as a student' do
               .to receive :configured_value
             allow_any_instance_of(ApplicationConfiguration)
               .to receive(:configured_value)
-              .with([:on_application_denial, :provide_reason], anything)
+              .with([:on_application_denial, :notify_of_reason], anything)
               .and_return true
           end
           it 'has link to see the denied app, with text of denial reason' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,4 +12,39 @@ describe ApplicationHelper do
       expect(text 'some random string').to be_blank
     end
   end
+
+  describe 'parse_application_data' do
+    before :each do
+      @data = {}
+      (0..4).each do |num|
+        %w(prompt response data_type).each do |type|
+          @data["#{type}_#{num}"] = "#{num}-#{type}"
+        end
+        @data[num.to_s] = "#{num}-#{num}"
+      end
+      @result = parse_application_data(@data)
+                .select { |sub| !sub.nil? && sub.all? }
+    end
+
+    it 'does not return nothing when given data' do
+      expect(@result.length).not_to be_zero
+    end
+
+    it 'generates the correct amount of data' do
+      expect(@result.length).to be(5)
+      @result.each do |subarray|
+        expect(subarray.length).to be(4)
+        expect(subarray.count(nil)).to be(0)
+      end
+    end
+
+    it 'generates proper data' do
+      @result.each_with_index do |subarray, index|
+        %w(prompt response data_type).each do |type|
+          expect(subarray).to include("#{index}-#{type}")
+        end
+        expect(subarray).to include(index + 1)
+      end
+    end
+  end
 end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -67,6 +67,44 @@ describe ApplicationRecord do
     end
   end
 
+  describe 'question_hash' do
+    include ApplicationHelper
+    before :each do
+      @data = {}
+      (0..4).each do |num|
+        %w(prompt response data_type).each do |type|
+          @data["#{type}_#{num}"] = "#{num}-#{type}"
+        end
+        @data[num.to_s] = "#{num}-#{num}"
+      end
+      @data_arr = parse_application_data(@data)
+                  .select { |sub| !sub.nil? && sub.all? }
+      @record = create :application_record, data: @data_arr
+      @hash = @record.questions_hash
+    end
+
+    it 'does not return nothing when given data' do
+      expect(@hash.length).not_to be_zero
+    end
+
+    it 'generates the correct amount of data' do
+      expect(@hash.length).to be(5)
+    end
+
+    it 'contains the correct keys and values' do
+      @record.data.each do |_, value, _, index|
+        expect(@hash.keys).to include(index)
+        expect(@hash.values).to include(value)
+      end
+    end
+
+    it 'maps to the correct values' do
+      @record.data.each do |_, value, _, index|
+        expect(@hash[index]).to be(value)
+      end
+    end
+  end
+
   describe 'between' do
     before :each do
       Timecop.freeze 1.week.ago do


### PR DESCRIPTION
Closes #28 

Some of this stuff can probably be tested, so it's probably not 1000% finished yet (nor have I run the local tests, just wanted to push this before I left for the day for review, so I assume checks will fail)

In the dump-y non-bootstrap interface, here's the look:

![screen shot 2016-04-04 at 6 50 35 pm](https://cloud.githubusercontent.com/assets/9220151/14266431/2c4e61ce-fa96-11e5-93d1-8a6a473f2547.png)

General idea:

 1. When saving a AppRecord, it will now save the question's ID in the data-arrays
 2. When you open a AppTemplate (to apply), it will now display an option to fill in the fields with data from past applications (to the same position, if they exist)
 3. Maps the 4-element sub-arrays into 2-element sub-arrays which are then converted into a hash using `.to_h`
 4. Using `question.id` as a key, it will attempt to rip previous answers from the hash. If it fails, it'll default to an empty field