### PR TITLE
Added EEO Data page spec

### DIFF
--- a/app/assets/stylesheets/application_records/eeo_display.scss
+++ b/app/assets/stylesheets/application_records/eeo_display.scss
@@ -1,4 +1,4 @@
-table#eeo_table{
+table.eeo_table{
   margin: 45px;
   border-collapse: collapse;
   text-align: left;

--- a/app/views/application_records/_combined_totals.haml
+++ b/app/views/application_records/_combined_totals.haml
@@ -1,4 +1,4 @@
-%table#eeo_table
+%table.eeo_table#combined_female_table
   %thead
     %tr
       %th Females by ethnicity
@@ -8,7 +8,7 @@
       %td= ethnicity
       %td= count
 
-%table#eeo_table
+%table.eeo_table#combined_male_table
   %thead
     %tr
       %th Males by ethnicity

--- a/app/views/application_records/_ethnicity_totals.haml
+++ b/app/views/application_records/_ethnicity_totals.haml
@@ -1,4 +1,4 @@
-%table#eeo_table
+%table.eeo_table#ethnicity_table
   %thead
     %tr
     %th Ethnicity

--- a/app/views/application_records/_gender_totals.haml
+++ b/app/views/application_records/_gender_totals.haml
@@ -1,4 +1,4 @@
-%table#eeo_table
+%table.eeo_table#gender_table
   %thead
     %tr
       %th Gender
@@ -7,4 +7,3 @@
     %tr
       %td= gender
       %td= count
-

--- a/app/views/application_records/eeo_data.haml
+++ b/app/views/application_records/eeo_data.haml
@@ -1,4 +1,4 @@
-%table.data_table.display
+%table.data_table.display#main_data_table
   %thead
     %tr
       %th Date Submitted

--- a/app/views/application_records/past_applications.haml
+++ b/app/views/application_records/past_applications.haml
@@ -1,4 +1,4 @@
-%table.data_table.display
+%table.data_table.display#main_data_table
   %thead
     %tr
       %th Date Submitted

--- a/spec/features/view_eeo_data_spec.rb
+++ b/spec/features/view_eeo_data_spec.rb
@@ -24,9 +24,10 @@ describe 'viewing eeo data page' do
     click_button 'List EEO data'
   end
 
-  it_behaves_like 'a data page', %w(data_table
-                                    ethnicity_table combined_male_table
-                                    gender_table combined_female_table)
+  it_behaves_like 'a data page',
+                  table_ids: %w(main_data_table
+                                ethnicity_table combined_male_table
+                                gender_table combined_female_table)
 
   it 'goes to the past applications page' do
     expect(page.current_url)

--- a/spec/features/view_eeo_data_spec.rb
+++ b/spec/features/view_eeo_data_spec.rb
@@ -23,6 +23,11 @@ describe 'viewing eeo data page' do
     fill_in 'eeo_end_date', with: end_date
     click_button 'List EEO data'
   end
+
+  it_behaves_like 'a data page', %w(data_table
+                                    ethnicity_table combined_male_table
+                                    gender_table combined_female_table)
+
   it 'goes to the past applications page' do
     expect(page.current_url)
       .to include eeo_data_application_records_url
@@ -56,12 +61,5 @@ describe 'viewing eeo data page' do
 
   it 'displays the formatted creation date of the application records' do
     expect(page).to have_text format_date_time record_with_eeo_data.created_at
-  end
-  it 'displays all of the proper tables' do
-    expect page.has_table? 'data_table'
-    expect page.has_table? 'ethnicity_table'
-    expect page.has_table? 'gender_table'
-    expect page.has_table? 'combined_male_table'
-    expect page.has_table? 'combined_female_table'
   end
 end

--- a/spec/features/view_eeo_data_spec.rb
+++ b/spec/features/view_eeo_data_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+include DateAndTimeMethods
+
+describe 'viewing eeo data page' do
+  # datepicker requires m/d/Y format
+  let(:start_date) { 1.week.ago.strftime('%m/%d/%Y') }
+  let(:end_date) { 1.week.since.strftime('%m/%d/%Y') }
+  let!(:record_with_eeo_data) do
+    create :application_record,
+           ethnicity: 'White (Not of Hispanic origin)',
+           gender: 'Male'
+  end
+  let!(:old_record_with_eeo_data) do
+    create :application_record,
+           created_at: 2.weeks.ago,
+           ethnicity: 'Black (Not of Hispanic origin)',
+           gender: 'Female'
+  end
+  before :each do
+    when_current_user_is :staff, integration: true
+    visit staff_dashboard_url
+    fill_in 'eeo_start_date', with: start_date
+    fill_in 'eeo_end_date', with: end_date
+    click_button 'List EEO data'
+  end
+  it 'goes to the past applications page' do
+    expect(page.current_url)
+      .to include eeo_data_application_records_url
+  end
+
+  it 'displays the ethnicity of valid applicant' do
+    within('table.data_table') do
+      expect(page)
+        .to have_text record_with_eeo_data.ethnicity
+    end
+  end
+  it 'displays the gender of valid applicant' do
+    within('table.data_table') do
+      expect(page)
+        .to have_text record_with_eeo_data.gender
+    end
+  end
+
+  it 'does not display ethnicity of outdated application' do
+    within('table.data_table') do
+      expect(page)
+        .not_to have_text old_record_with_eeo_data.ethnicity
+    end
+  end
+  it 'does not display the gender of outdated application' do
+    within('table.data_table') do
+      expect(page)
+        .not_to have_text old_record_with_eeo_data.gender
+    end
+  end
+
+  it 'displays the formatted creation date of the application records' do
+    expect(page).to have_text format_date_time record_with_eeo_data.created_at
+  end
+  it 'displays all of the proper tables' do
+    expect page.has_table? 'data_table'
+    expect page.has_table? 'ethnicity_table'
+    expect page.has_table? 'gender_table'
+    expect page.has_table? 'combined_male_table'
+    expect page.has_table? 'combined_female_table'
+  end
+end

--- a/spec/features/viewing_past_applications_table_spec.rb
+++ b/spec/features/viewing_past_applications_table_spec.rb
@@ -22,7 +22,7 @@ describe 'viewing table of past applications' do
     click_button 'List Applications'
   end
 
-  it_behaves_like 'a data page', ['data_table']
+  it_behaves_like 'a data page', %w(data_table)
 
   it 'goes to the past applications page' do
     expect(page.current_url)

--- a/spec/features/viewing_past_applications_table_spec.rb
+++ b/spec/features/viewing_past_applications_table_spec.rb
@@ -21,6 +21,9 @@ describe 'viewing table of past applications' do
     fill_in 'records_end_date', with: end_date
     click_button 'List Applications'
   end
+
+  it_behaves_like 'a data page', ['data_table']
+
   it 'goes to the past applications page' do
     expect(page.current_url)
       .to include past_applications_application_records_url
@@ -31,9 +34,6 @@ describe 'viewing table of past applications' do
   end
   it 'displays the formatted creation date of the application records' do
     expect(page).to have_text format_date_time record.created_at
-  end
-  it 'displays a table of application records' do
-    expect page.has_table? 'data_table'
   end
   it 'displays the staff note of the applications' do
     expect(page).to have_text record.staff_note

--- a/spec/features/viewing_past_applications_table_spec.rb
+++ b/spec/features/viewing_past_applications_table_spec.rb
@@ -22,12 +22,13 @@ describe 'viewing table of past applications' do
     click_button 'List Applications'
   end
 
-  it_behaves_like 'a data page', %w(data_table)
+  it_behaves_like 'a data page', table_ids: %w(main_data_table)
 
   it 'goes to the past applications page' do
     expect(page.current_url)
       .to include past_applications_application_records_url
   end
+
   it 'lists the proper name of applicants' do
     expect(page)
       .to have_text "#{record.user.last_name}, #{record.user.first_name}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ RSpec.configure do |config|
   end
   config.include FactoryGirl::Syntax::Methods
   config.include UmtsCustomMatchers
-  Dir['./spec/support/**/*_shared_example.rb'].sort.each { |f| require f }
+  Dir['./spec/support/**/*_shared_example.rb'].each { |f| require f }
 end
 
 # controller spec helper methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   end
   config.include FactoryGirl::Syntax::Methods
   config.include UmtsCustomMatchers
+  Dir['./spec/support/**/*_shared_example.rb'].sort.each { |f| require f }
 end
 
 # controller spec helper methods

--- a/spec/support/shared_examples/data_page_shared_example.rb
+++ b/spec/support/shared_examples/data_page_shared_example.rb
@@ -1,0 +1,7 @@
+shared_examples 'a data page' do |tables|
+  it 'contains all requires tables' do
+    tables.each do |table_name|
+      expect page.has_table? table_name
+    end
+  end
+end

--- a/spec/support/shared_examples/data_page_shared_example.rb
+++ b/spec/support/shared_examples/data_page_shared_example.rb
@@ -1,7 +1,7 @@
-shared_examples 'a data page' do |tables|
+shared_examples 'a data page' do |table_ids:|
   it 'contains all requires tables' do
-    tables.each do |table_name|
-      expect page.has_table? table_name
+    table_ids.each do |table_id|
+      expect(page).to have_table table_id
     end
   end
 end


### PR DESCRIPTION
Closes #232 

Also, as a rule of thumb: CSS IDs should not be duplicated (much like IDs in Rails, which **can't** be duplicated). If you find a situation where you think something should have the same ID, it's likely supposed to be a class instead. Use IDs as a delimiter between objects of the same class or if there is only one object that would reasonably have said ID (like the `data-table`, but even then it seems more like a class than an ID). I've modified the CSS to reflect this as well.