### PR TITLE
Position not hiring

### DIFF
--- a/app/assets/stylesheets/subscriptions.scss
+++ b/app/assets/stylesheets/subscriptions.scss
@@ -1,12 +1,10 @@
-.subscriptions {
-  margin-left: -2em;
-  margin-top: 1em;
-  .subscription_email{
-    padding: .5em; 
-    li {
-      float: left;
-      list-style-type: none;
-      margin-right: 1em;
+.subscriptions{
+  ul.list-group {
+    li.list-group-item{
+      overflow: hidden;
+      form{
+        float: right;
+      }
     }
   }
-} 
+}

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -42,6 +42,7 @@ class PositionsController < ApplicationController
   def position_parameters
     params.require(:position).permit :default_interview_location,
                                      :department_id,
-                                     :name
+                                     :name,
+                                     :not_hiring_text
   end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -14,12 +14,10 @@ class Position < ActiveRecord::Base
 
   default_scope { order :name }
 
+  NOT_HIRING = "We are not currently hiring for #{name}. Please check back."
+
   def name_and_department
     "#{name} (#{department.name})"
-  end
-
-  def default_not_hiring_text
-    "We are not currently hiring for #{name}. Please check back."
   end
 
   def configured_not_hiring_text

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -14,10 +14,12 @@ class Position < ActiveRecord::Base
 
   default_scope { order :name }
 
-  NOT_HIRING = "We are not currently hiring for #{name}. Please check back."
-               .freeze
-
   def name_and_department
     "#{name} (#{department.name})"
+  end
+
+  def not_hiring
+    not_hiring_text ||
+      "We are not currently hiring for #{name}. Please check back."
   end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -15,6 +15,7 @@ class Position < ActiveRecord::Base
   default_scope { order :name }
 
   NOT_HIRING = "We are not currently hiring for #{name}. Please check back."
+               .freeze
 
   def name_and_department
     "#{name} (#{department.name})"

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -19,10 +19,4 @@ class Position < ActiveRecord::Base
   def name_and_department
     "#{name} (#{department.name})"
   end
-
-  def configured_not_hiring_text
-    configured_value([:deactivated_application,
-                      yamlize(department.name), yamlize(name)],
-                     default: default_not_hiring_text)
-  end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -20,6 +20,6 @@ class Position < ActiveRecord::Base
 
   def not_hiring
     not_hiring_text ||
-      "We are not currently hiring for #{name}. Please check back."
+      "We are not currently hiring for #{name}."
   end
 end

--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -149,4 +149,4 @@
 
       .actions= submit_tag 'Submit application' unless @current_user.try :staff?
 - else
-  .note_item This application is currently unavailable. Please check back.
+  .note_item=@template.position.not_hiring_text

--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -149,4 +149,4 @@
 
       .actions= submit_tag 'Submit application' unless @current_user.try :staff?
 - else
-  .note_item=@template.position.not_hiring_text
+  .note_item= @template.position.not_hiring_text

--- a/app/views/dashboard/student.haml
+++ b/app/views/dashboard/student.haml
@@ -36,4 +36,4 @@ Please select the application which you would like to submit.
           application_path(position.application_template)
     - else
       %li
-        = position.configured_not_hiring_text
+        = position.not_hiring_text || Position::NOT_HIRING

--- a/app/views/dashboard/student.haml
+++ b/app/views/dashboard/student.haml
@@ -36,4 +36,4 @@ Please select the application which you would like to submit.
           application_path(position.application_template)
     - else
       %li
-        = position.not_hiring_text || Position::NOT_HIRING
+        = position.not_hiring

--- a/app/views/positions/_form.haml
+++ b/app/views/positions/_form.haml
@@ -14,10 +14,9 @@
       = f.text_field :default_interview_location,
         required: false, class: 'form-control'
     .form-group
-      = f.label :not_hiring_text
-      %em This text will be displayed on the student dashboard
-      %em instead of the link to the application
+      = f.label 'Text to display to students when not hiring'
       = f.text_area :not_hiring_text,
-        class: 'form-control'
+        class: 'form-control',
+        placeholder: 'Default: We are not currently hiring for this position'
     .actions
       = f.submit 'Save changes'

--- a/app/views/positions/_form.haml
+++ b/app/views/positions/_form.haml
@@ -1,14 +1,23 @@
-= form_for position,
-  url: { controller: :positions, action: action, id: position.id } do |f|
-  .field
-    = f.label :department_id
-    = f.select :department_id,
-      options_from_collection_for_select(Department.all, :id, :name)
-  .field
-    = f.label :name
-    = f.text_field :name, required: true
-  .field
-    = f.label :default_interview_location
-    = f.text_field :default_interview_location, required: false
-  .action
-    = f.submit 'Save changes'
+%form
+  = form_for position,
+    url: { controller: :positions, action: action, id: position.id } do |f|
+    .row
+      .form-group.col-md-4
+        = f.label :department_id
+        = f.collection_select :department_id, Department.all, :id, :name,
+          {}, {class: 'form-control'}
+    .form-group
+      = f.label :name
+      = f.text_field :name, required: true, class: 'form-control'
+    .form-group
+      = f.label :default_interview_location
+      = f.text_field :default_interview_location,
+        required: false, class: 'form-control'
+    .form-group
+      = f.label :not_hiring_text
+      %em This text will be displayed on the student dashboard
+      %em instead of the link to the application
+      = f.text_area :not_hiring_text,
+        class: 'form-control'
+    .actions
+      = f.submit 'Save changes'

--- a/app/views/positions/_form.haml
+++ b/app/views/positions/_form.haml
@@ -14,7 +14,7 @@
       = f.text_field :default_interview_location,
         required: false, class: 'form-control'
     .form-group
-      = f.label 'Text to display to students when not hiring'
+      = f.label 'Text to display to students when application is inactive'
       = f.text_area :not_hiring_text,
         class: 'form-control',
         placeholder: position.not_hiring_text || Position::NOT_HIRING

--- a/app/views/positions/_form.haml
+++ b/app/views/positions/_form.haml
@@ -17,6 +17,6 @@
       = f.label 'Text to display to students when not hiring'
       = f.text_area :not_hiring_text,
         class: 'form-control',
-        placeholder: 'Default: We are not currently hiring for this position'
+        placeholder: position.not_hiring_text || Position::NOT_HIRING
     .actions
       = f.submit 'Save changes'

--- a/app/views/positions/_form.haml
+++ b/app/views/positions/_form.haml
@@ -16,6 +16,6 @@
     = f.label 'Text to display to students when application is inactive'
     = f.text_area :not_hiring_text,
       class: 'form-control',
-      placeholder: position.not_hiring_text || Position::NOT_HIRING
+      placeholder: position.not_hiring
   .actions
     = f.submit 'Save changes'

--- a/app/views/positions/_form.haml
+++ b/app/views/positions/_form.haml
@@ -1,22 +1,21 @@
-%form
-  = form_for position,
-    url: { controller: :positions, action: action, id: position.id } do |f|
-    .row
-      .form-group.col-md-4
-        = f.label :department_id
-        = f.collection_select :department_id, Department.all, :id, :name,
-          {}, {class: 'form-control'}
-    .form-group
-      = f.label :name
-      = f.text_field :name, required: true, class: 'form-control'
-    .form-group
-      = f.label :default_interview_location
-      = f.text_field :default_interview_location,
-        required: false, class: 'form-control'
-    .form-group
-      = f.label 'Text to display to students when application is inactive'
-      = f.text_area :not_hiring_text,
-        class: 'form-control',
-        placeholder: position.not_hiring_text || Position::NOT_HIRING
-    .actions
-      = f.submit 'Save changes'
+= form_for position,
+  url: { controller: :positions, action: action, id: position.id } do |f|
+  .row
+    .form-group.col-md-4
+      = f.label :department_id
+      = f.collection_select :department_id, Department.all, :id, :name,
+        {}, {class: 'form-control'}
+  .form-group
+    = f.label :name
+    = f.text_field :name, required: true, class: 'form-control'
+  .form-group
+    = f.label :default_interview_location
+    = f.text_field :default_interview_location,
+      required: false, class: 'form-control'
+  .form-group
+    = f.label 'Text to display to students when application is inactive'
+    = f.text_area :not_hiring_text,
+      class: 'form-control',
+      placeholder: position.not_hiring_text || Position::NOT_HIRING
+  .actions
+    = f.submit 'Save changes'

--- a/app/views/positions/edit.haml
+++ b/app/views/positions/edit.haml
@@ -2,7 +2,7 @@
 
 = render 'form', position: @position, action: :update
 
-= button_to "Remove #{@position.name_and_department}",
+.actions= button_to "Remove #{@position.name_and_department}",
   @position, method: :delete
 %h2 Subscribe to email notifications
 %p You will be notified when someone fills out an application.
@@ -15,9 +15,12 @@
   = f.submit 'Subscribe'
 - if @subscriptions.present?
   %p Your currently subscribed emails:
-  %ul.subscriptions
-    - @subscriptions.each do |subscription|
-      %li.subscription_email=subscription.email
-      = button_to 'Remove', subscription, method: :delete
+  .subscriptions
+    %ul.list-group
+      - @subscriptions.each do |subscription|
+        %li.list-group-item
+          =subscription.email
+          =button_to subscription_path(subscription), {method: :delete, class: 'btn btn-default'} do
+            %i.glyphicon.glyphicon-remove-circle
 - else
   %p You are not currently subscribed.

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -6,16 +6,6 @@
 # This value will populate landing pages, page titles, and email templates.
 organization_name: 'UMass Transit'
 
-deactivated_application:
-# This is the text shown to applicants when the application is inactive.
-# Follow the template like so. Make sure all names are underscored and
-# lowercased.
-  special_transportation:
-    van_driver: 'We are not currently hiring van drivers'
-  bus:
-    operator: 'We are not currently hiring bus drivers'
-    cleaner: 'We do not currently need any bus cleaners'
-
 email:
   # This value determines where site emails will be sent from (e.g. noreply).
   default_from: 'transit-it@admin.umass.edu'

--- a/db/migrate/20160703170621_add_not_hiring_text_to_position.rb
+++ b/db/migrate/20160703170621_add_not_hiring_text_to_position.rb
@@ -1,0 +1,5 @@
+class AddNotHiringTextToPosition < ActiveRecord::Migration
+  def change
+    add_column :positions, :not_hiring_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160615163009) do
+ActiveRecord::Schema.define(version: 20160703170621) do
 
   create_table "application_drafts", force: :cascade do |t|
     t.integer  "application_template_id", limit: 4
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 20160615163009) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "default_interview_location", limit: 255
+    t.string   "not_hiring_text",            limit: 255
   end
 
   create_table "questions", force: :cascade do |t|

--- a/lib/application_configuration.rb
+++ b/lib/application_configuration.rb
@@ -23,8 +23,4 @@ module ApplicationConfiguration
             and default not specified."
     end
   end
-
-  def yamlize(string)
-    string.underscore.tr(' ', '_').to_sym
-  end
 end

--- a/spec/features/application_record_creation_spec.rb
+++ b/spec/features/application_record_creation_spec.rb
@@ -24,8 +24,7 @@ describe 'submitting application records' do
         visit current_url
         # must reload the page for changes to template to take effect
         expect(page)
-          .to have_text('This application is currently unavailable.
-                      Please check back')
+          .to have_text application_template.position.not_hiring_text
       end
     end
   end
@@ -53,8 +52,7 @@ describe 'submitting application records' do
         visit current_url
         # must reload the page for changes to template to take effect
         expect(page)
-          .to have_text('This application is currently unavailable.
-                      Please check back')
+          .to have_text application_template.position.not_hiring_text
       end
     end
   end

--- a/spec/features/student_dashboard_view_spec.rb
+++ b/spec/features/student_dashboard_view_spec.rb
@@ -117,58 +117,48 @@ describe 'viewing the dashboard as a student' do
     end # of student did not get an interview
   end # of student has submitted an application
   context 'student has not yet submitted an application' do
+    let!(:position_not_hiring) { create :position }
     before :each do
       visit student_dashboard_url
     end
     context 'position exists, but applications have not been created' do
-      let!(:positn_not_hiring) { create :position }
-      context 'deactivated application text has been configured' do
+      context 'user has changed the not hiring text' do
         it 'displays the custom text for the position not hiring' do
-          allow_any_instance_of(Position)
-            .to receive(:configured_not_hiring_text)
-          expect_any_instance_of(Position)
-            .to receive(:configured_not_hiring_text)
-            .and_return 'custom text'
+          position_not_hiring.update_attributes(not_hiring_text: 'custom text')
           visit current_url
           expect(page).to have_text 'custom text'
         end
       end
-      context 'deactivated application text has not been configured' do
-        it 'displays the default not-hiring text' do
-          expect(page)
-            .to have_text
-          "Applications are currently unavailable for #{positn_not_hiring.name}"
+      context 'user has not edited the not hiring text' do
+        it 'displays the constant not-hiring text' do
+          visit current_url
+          expect(page).to have_text Position::NOT_HIRING
         end
       end
     end
     context 'applications have been created for a position, but are inactive' do
       let!(:inactive_app) do
         create :application_template,
-               active: false
+               active: false,
+               position: position_not_hiring
       end
-      context 'deactivated application text has been configured' do
+      context 'deactivated application text has been edited' do
         it 'displays the custom text for the position not hiring' do
-          allow_any_instance_of(Position)
-            .to receive(:configured_not_hiring_text)
-          expect_any_instance_of(Position)
-            .to receive(:configured_not_hiring_text)
-            .and_return 'custom text'
+          position_not_hiring.update_attributes(not_hiring_text: 'custom text')
           visit current_url
           expect(page).to have_text 'custom text'
         end
       end
-      context 'deactivated application text has not been configured' do
+      context 'deactivated application text has not been edited' do
         it 'displays the default not-hiring text' do
-          expect(page)
-            .to have_text
-          "We are not currently hiring for #{inactive_app.position.name}"
+          visit current_url
+          expect(page).to have_text Position::NOT_HIRING
         end
       end
     end
     context 'applications are active for that position' do
       let!(:active_application) do
-        create :application_template,
-               active: true
+        create :application_template, active: true
       end
       it 'shows links to submit the application' do
         visit current_url

--- a/spec/features/student_dashboard_view_spec.rb
+++ b/spec/features/student_dashboard_view_spec.rb
@@ -130,9 +130,10 @@ describe 'viewing the dashboard as a student' do
         end
       end
       context 'user has not edited the not hiring text' do
-        it 'displays the constant not-hiring text' do
+        it 'displays a boiler-plate not-hiring text' do
           visit current_url
-          expect(page).to have_text Position::NOT_HIRING
+          expect(page)
+            .to have_text "not currently hiring for #{position_not_hiring.name}"
         end
       end
     end
@@ -152,7 +153,8 @@ describe 'viewing the dashboard as a student' do
       context 'deactivated application text has not been edited' do
         it 'displays the default not-hiring text' do
           visit current_url
-          expect(page).to have_text Position::NOT_HIRING
+          expect(page)
+            .to have_text "not currently hiring for #{position_not_hiring.name}"
         end
       end
     end

--- a/spec/features/student_dashboard_view_spec.rb
+++ b/spec/features/student_dashboard_view_spec.rb
@@ -124,7 +124,7 @@ describe 'viewing the dashboard as a student' do
     context 'position exists, but applications have not been created' do
       context 'user has changed the not hiring text' do
         it 'displays the custom text for the position not hiring' do
-          position_not_hiring.update_attributes(not_hiring_text: 'custom text')
+          position_not_hiring.update(not_hiring_text: 'custom text')
           visit current_url
           expect(page).to have_text 'custom text'
         end
@@ -145,7 +145,7 @@ describe 'viewing the dashboard as a student' do
       end
       context 'deactivated application text has been edited' do
         it 'displays the custom text for the position not hiring' do
-          position_not_hiring.update_attributes(not_hiring_text: 'custom text')
+          position_not_hiring.update(not_hiring_text: 'custom text')
           visit current_url
           expect(page).to have_text 'custom text'
         end

--- a/spec/features/subscription_service_spec.rb
+++ b/spec/features/subscription_service_spec.rb
@@ -44,8 +44,8 @@ describe 'subscriptions' do
     end
     it 'removes the email from the page when remove is clicked' do
       form = within('.subscriptions') do
-               find('form.button_to')
-             end
+        find('form.button_to')
+      end
       within(form) { find('button').click }
       expect(page).not_to have_text subscription.email
     end

--- a/spec/features/subscription_service_spec.rb
+++ b/spec/features/subscription_service_spec.rb
@@ -43,9 +43,7 @@ describe 'subscriptions' do
       visit edit_position_path(position)
     end
     it 'removes the email from the page when remove is clicked' do
-      form = within('.subscriptions') do
-        find('form.button_to')
-      end
+      form = within('.subscriptions') { find('form.button_to') }
       within(form) { find('button').click }
       expect(page).not_to have_text subscription.email
     end

--- a/spec/features/subscription_service_spec.rb
+++ b/spec/features/subscription_service_spec.rb
@@ -43,7 +43,10 @@ describe 'subscriptions' do
       visit edit_position_path(position)
     end
     it 'removes the email from the page when remove is clicked' do
-      click_button 'Remove'
+      form = within('.subscriptions') do
+               find('form.button_to')
+             end
+      within(form) { find('button').click }
       expect(page).not_to have_text subscription.email
     end
   end


### PR DESCRIPTION
Position page looks nicer. Also, you can configure the "we aren't hiring right now" text directly from the position page.
closes #258 
![screen shot 2016-07-06 at 11 50 28 am](https://cloud.githubusercontent.com/assets/9645316/16624734/dd80af84-436f-11e6-8d20-15b280db6aac.png)
