### PR TITLE
between scope now actually inclusive with dates

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -14,7 +14,9 @@ class ApplicationRecord < ActiveRecord::Base
   validates :reviewed, inclusion: { in: [true, false] }
 
   scope :between,
-    -> (start_date, end_date) { where created_at: start_date..end_date.end_of_day }
+        lambda { |start_date, end_date|
+          where created_at: start_date..end_date.end_of_day
+        }
   scope :in_department,
         lambda { |department_ids|
           joins(:position)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -14,7 +14,7 @@ class ApplicationRecord < ActiveRecord::Base
   validates :reviewed, inclusion: { in: [true, false] }
 
   scope :between,
-        -> (start_date, end_date) { where created_at: start_date..end_date }
+    -> (start_date, end_date) { where created_at: start_date..end_date.end_of_day }
   scope :in_department,
         lambda { |department_ids|
           joins(:position)

--- a/spec/features/application_record_pdf_generation_spec.rb
+++ b/spec/features/application_record_pdf_generation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'generating a pdf to print an application record' do
-  let(:unavail) { create :unavailability, sunday: ["7AM"] }
+  let(:unavail) { create :unavailability, sunday: ['7AM'] }
   let(:record) { create :application_record, unavailability: unavail }
   before :each do
     when_current_user_is :staff, integration: true

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -77,6 +77,9 @@ describe ApplicationRecord do
       Timecop.freeze 1.month.since do
         @too_future_record = create :application_record
       end
+      Timecop.freeze 1.week.since do
+        @almost_too_future_record = create :application_record
+      end
       @just_right_record = create :application_record
       @start_date = Time.zone.today
       @end_date = 1.week.since
@@ -85,7 +88,7 @@ describe ApplicationRecord do
       ApplicationRecord.between @start_date, @end_date
     end
     it 'gives the application records between the given dates' do
-      expect(call).to include @just_right_record
+      expect(call).to include @just_right_record, @almost_too_future_record
       expect(call).not_to include @too_future_record, @too_past_record
     end
   end


### PR DESCRIPTION
When giving an end_date to a record search--say it's the 7th, that would get saved as the beginning of the 7th -- midnight of the night before. Any records created on the 7th would not be included. Now it searches until the end of the day.

closes #267 