### PR TITLE
Ensure User Creation Has '@umass.edu' in SPIRE Field

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
             presence: true
   validates :staff, inclusion: { in: [true, false],
                                  message: 'must be true or false' }
-  validates :spire, uniqueness: true
+  validates :spire, uniqueness: true, format: {with: /@umass\.edu\z/}
 
   default_scope { order :last_name, :first_name }
   scope :staff,    -> { where staff: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
             presence: true
   validates :staff, inclusion: { in: [true, false],
                                  message: 'must be true or false' }
-  validates :spire, uniqueness: true, format: {with: /@umass\.edu\z/}
+  validates :spire, uniqueness: true, format: {with: /\d{8}@umass\.edu/}
 
   default_scope { order :last_name, :first_name }
   scope :staff,    -> { where staff: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
             presence: true
   validates :staff, inclusion: { in: [true, false],
                                  message: 'must be true or false' }
-  validates :spire, uniqueness: true, format: {with: /\d{8}@umass\.edu/}
+  validates :spire, uniqueness: true, format: { with: /\A\d{8}@umass\.edu\z/ }
 
   default_scope { order :last_name, :first_name }
   scope :staff,    -> { where staff: true }

--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -11,7 +11,7 @@
     = f.text_field :email, required: true
   .form-group.row
     .col-md-2= f.label :spire
-    = f.text_field :spire, required: true
+    = f.text_field :spire, required: true, placeholder: 'username@umass.edu'
   .action
     = f.hidden_field :staff, value: true
     .btn= f.submit 'Save changes'

--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -11,7 +11,7 @@
     = f.text_field :email, required: true
   .form-group.row
     .col-md-2= f.label :spire
-    = f.text_field :spire, required: true, placeholder: 'username@umass.edu'
+    = f.text_field :spire, required: true, placeholder: 'Spire-Id@umass.edu'
   .action
     = f.hidden_field :staff, value: true
     .btn= f.submit 'Save changes'

--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -11,7 +11,7 @@
     = f.text_field :email, required: true
   .form-group.row
     .col-md-2= f.label :spire
-    = f.text_field :spire, required: true, placeholder: 'Spire-Id@umass.edu'
+    = f.text_field :spire, required: true, placeholder: 'e.g. 12345678@umass.edu'
   .action
     = f.hidden_field :staff, value: true
     .btn= f.submit 'Save changes'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,8 @@ ActiveRecord::Schema.define(version: 20160908152707) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "position_id",            limit: 4
-    t.boolean  "active"
+    t.boolean  "visible",                            default: true
+    t.boolean  "active",                             default: true
     t.string   "slug",                   limit: 255
     t.boolean  "eeo_enabled",                        default: true
     t.string   "email",                  limit: 255

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     first_name 'FirstName'
     last_name  'LastName'
     staff      false
-    sequence(:spire) { |n| n.to_s.rjust 8, '0' }
+    sequence(:spire) { |n| n.to_s.rjust(8, '0') + '@umass.edu' }
 
     trait :staff do
       staff true


### PR DESCRIPTION
Closes #266.  Adds a placeholder to the SPIRE field on `Users#new` and adds a validation in the User model to check that this field receives 8 digits followed by '@umass.edu'.  Previously, we only validated `presence` and `uniqueness`.  