### PR TITLE
pre-fill application template email

### DIFF
--- a/app/views/application_drafts/edit.haml
+++ b/app/views/application_drafts/edit.haml
@@ -79,7 +79,9 @@
         .field_attribute_header1
           Reply-to email:
         .field_attribute
-          =f.text_field :email, size: 50
+          =f.text_field :email,
+            value: @draft.application_template.email,
+            size: 50
       .actions
         = f.submit 'Save changes and continue editing'
         = f.submit 'Preview changes'


### PR DESCRIPTION
closes #273

Turns out the params for "email" were just getting sent as blank because the value wasn't pre-filled.

@werebus... I have failed. It was 40 characters.