### PR TITLE
Change the path to where ruby will be

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-env 'PATH', '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+env 'PATH', '/opt/ruby/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 every :day, at: '12:00am' do
   runner 'ApplicationSubmission.move_to_dashboard'


### PR DESCRIPTION
I'm changing the method of ruby installation in production to make upgrades easier.