### PR TITLE
Applied design changes to application review page.

### DIFF
--- a/app/assets/stylesheets/application_records/show.scss
+++ b/app/assets/stylesheets/application_records/show.scss
@@ -30,5 +30,15 @@
 }
 
 .note_item{
-  margin: 1em;
+    textarea{
+        width: 50%;
+    }
+    
+    justify-content: right;
+    margin: 1em;
+    font-weight: normal;
+    
 }
+h4{
+    margin-left: 0.5em;
+    }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -33,6 +33,7 @@
       color:          black;
       font-size: 100%;
       line-height: 1.25;
+      font-weight: normal;
     }
     input[type='number']{
       width: 3em;

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -39,28 +39,35 @@ by:
 - if @current_user.staff?
   - if @record.pending?
     %h3 Review application
+    %h4 Deny Application
     = form_tag controller: :application_submissions,
       action: :review,
       id: @record.id,
       accepted: false do
       .field.note_item
+        %p
+        <b>
         Reason for rejection:
+        </b>
+        %p
         = text_area_tag :staff_note, ''
       .text.note_item
         - if configured_value [:on_application_denial, :provide_reason],
                               default: true
+          %em
           These notes will be provided to the applicant.
         - else
           These notes will not be provided to the applicant.
       .note_item
-        = submit_tag 'Review application without scheduling interview'
+        = submit_tag 'Submit'
     = form_tag controller: :application_submissions,
       action: :review,
       id: @record.id,
       accepted: true do
+      %h4 Approve Application and Schedule Interview
       = fields_for :interview do |f|
         .field.note_item
-          = f.label :scheduled, 'Date and time of interview'
+          = f.label :scheduled, 'Date/time'
           = f.text_field :scheduled,
             class: 'datetimepicker',
             placeholder: 'Click here to select date/time...',
@@ -70,7 +77,7 @@ by:
           = f.text_field :location,
                          required: true,
                          value: @record.position.default_interview_location
-      .note_item= submit_tag 'Review application and schedule interview'
+      .note_item= submit_tag 'Submit'
     - if @record.saved_for_later?
       - if @record.note_for_later.present?
         Note:
@@ -85,20 +92,24 @@ by:
       = form_tag controller: :application_submissions,
         action: :toggle_saved_for_later,
         id: @record.id do
-        %p
-          Note
+        .field.note_item
+          %p
+          <b>Note: </b>
+          %p
           = text_area_tag :note_for_later, '', required: true
-        %p
+        .text.node_item
+        %p.note_item
           Email note to applicant:
           =check_box_tag :mail_to_applicant
         %p
+        %p.note_item
           %em
             This note will be listed as the reason their application was
             saved for review at a later date.
-        %p
-          Select a date for later review
+        %p.note_item
+          <b>Select a date for later review</b>
           = text_field_tag :date_for_later, '', class: 'datepicker'
-        %p
+        %p.note_item
           %em
             If a date is selected, the application will move back onto the
             dashboard at that time.
@@ -106,8 +117,7 @@ by:
           %em
             Get notified when this happens:
           = text_field_tag :email_to_notify, '', placeholder: 'person@example.com'
-          .note_item
-          = submit_tag 'Save for later'
+          .note_item=submit_tag 'Submit'
   - else
     .note_item
       Application reviewed on:

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -97,7 +97,6 @@ by:
           <b>Note: </b>
           %p
           = text_area_tag :note_for_later, '', required: true
-        .text.node_item
         %p.note_item
           Email note to applicant:
           =check_box_tag :mail_to_applicant

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -54,12 +54,12 @@ by:
       .text.note_item
         - if configured_value [:on_application_denial, :provide_reason],
                               default: true
-          %em
-          These notes will be provided to the applicant.
+          <i>
+          These notes will be provided to the applicant.</i>
         - else
           These notes will not be provided to the applicant.
       .note_item
-        = submit_tag 'Submit'
+        = submit_tag 'Decline'
     = form_tag controller: :application_submissions,
       action: :review,
       id: @record.id,
@@ -77,7 +77,7 @@ by:
           = f.text_field :location,
                          required: true,
                          value: @record.position.default_interview_location
-      .note_item= submit_tag 'Submit'
+      .note_item= submit_tag 'Approve'
     - if @record.saved_for_later?
       - if @record.note_for_later.present?
         Note:
@@ -117,7 +117,7 @@ by:
           %em
             Get notified when this happens:
           = text_field_tag :email_to_notify, '', placeholder: 'person@example.com'
-          .note_item=submit_tag 'Submit'
+          .note_item=submit_tag 'Save'
   - else
     .note_item
       Application reviewed on:

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -2,6 +2,7 @@ default: &default
   adapter: mysql2
   pool: 5
   timeout: 5000
+ 
 
 development:
   <<: *default

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -2,7 +2,6 @@ default: &default
   adapter: mysql2
   pool: 5
   timeout: 5000
- 
 
 development:
   <<: *default

--- a/spec/features/application_submission_save_for_later_spec.rb
+++ b/spec/features/application_submission_save_for_later_spec.rb
@@ -13,7 +13,7 @@ describe 'saving or unsaving applications' do
       click_link record.user.proper_name,
                  href: application_submission_path(record)
       page.fill_in 'note_for_later', with: 'This is required'
-      click_button 'Save for later'
+      click_button 'Save'
     end
     it 'displays the number of saved applications in the link to their page' do
       name = record.position.name
@@ -71,7 +71,7 @@ describe 'saving or unsaving applications' do
       visit application_submission_url(record)
       page.fill_in 'note_for_later', with: 'This is my note'
       page.fill_in 'date_for_later', with: Time.zone.today.strftime('%m/%d/%Y')
-      click_button 'Save for later'
+      click_button 'Save'
       record.reload
       expect(record.note_for_later).to eql 'This is my note'
       expect(record.date_for_later).to eql Time.zone.today

--- a/spec/features/viewing_applications_spec.rb
+++ b/spec/features/viewing_applications_spec.rb
@@ -33,14 +33,14 @@ describe 'viewing job applications individually' do
       click_link unreviewed_record.user.proper_name,
                  href: application_submission_path(unreviewed_record)
       fill_in 'staff_note', with: 'note'
-      click_button 'Review application without scheduling interview'
+      click_button 'Decline'
       expect(page.current_url).to eql staff_dashboard_url
       expect(page).to have_text 'Application has been marked as reviewed'
     end
     it 'provides a means to reject the application without a staff note' do
       click_link unreviewed_record.user.proper_name,
                  href: application_submission_path(unreviewed_record)
-      click_button 'Review application without scheduling interview'
+      click_button 'Decline'
       expect(page.current_url).to eql staff_dashboard_url
       expect(page).to have_text 'Application has been marked as reviewed'
     end
@@ -49,7 +49,7 @@ describe 'viewing job applications individually' do
                  href: application_submission_path(unreviewed_record)
       fill_in 'interview[scheduled]', with: 1.week.since
       fill_in 'interview[location]', with: 'A Place'
-      click_button 'Review application and schedule interview'
+      click_button 'Approve'
       expect(page.current_url).to eql staff_dashboard_url
       expect(page).to have_text 'Application has been marked as reviewed'
     end


### PR DESCRIPTION
Closes #315 
Here is a screenshot of the new design. 
<img width="771" alt="Screen Shot 2019-06-06 at 3 51 40 PM" src="https://user-images.githubusercontent.com/12656859/59062655-5e3ab380-8874-11e9-8920-6c0c15290f65.png">

Compared to the previous design:
![34004624-65659b54-e0c6-11e7-9304-539f54ece20c](https://user-images.githubusercontent.com/12656859/59062950-0c465d80-8875-11e9-959f-203c5937df84.png)


- Created more defined blocks between application denial/approval and interview scheduling.
- Fixed the issue of alignment of textboxes.
- Added bold attribute to certain important texts.
