### PR TITLE
don't hide div now that box is checked automatically

### DIFF
--- a/app/assets/stylesheets/application_records/show.scss
+++ b/app/assets/stylesheets/application_records/show.scss
@@ -6,6 +6,3 @@
 #notification{
   display: none;
 }
-.rejection-message{
-  display: none;
-}


### PR DESCRIPTION
the "tell them why" box should show on page load, as "notify applicant
of denial" is checked"