### PR TITLE
Display dates in datepick format

### DIFF
--- a/config/initializers/date_time.rb
+++ b/config/initializers/date_time.rb
@@ -1,0 +1,2 @@
+
+Date::DATE_FORMATS[:default] = "%m/%d/%Y"


### PR DESCRIPTION
Closes #363 

Added an initializer that sets the global default display format for dates to match that of the date picker.