### PR TITLE
Refactor "parse" helpers

### DIFF
--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -12,7 +12,7 @@ class ApplicationSubmissionsController < ApplicationController
 
   def create
     create_user if @current_user.blank?
-    data = ApplicationDataParserer.new(params.require(:data)).result
+    data = ApplicationDataParser.new(params.require(:data)).result
     params.require :position_id
     record = ApplicationSubmission.create(record_params
                                           .merge(data: data,

--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -12,7 +12,7 @@ class ApplicationSubmissionsController < ApplicationController
 
   def create
     create_user if @current_user.blank?
-    data = parse_application_data(params.require :data)
+    data = ApplicationDataParserer.new(params.require(:data)).result
     params.require :position_id
     record = ApplicationSubmission.create(record_params
                                           .merge(data: data,

--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require 'prawn'
 class ApplicationSubmissionsController < ApplicationController
-  include ApplicationHelper
-
   skip_before_action :access_control, only: %i[create show]
   before_action :find_record, except: %i[create
                                          csv_export
@@ -109,9 +106,8 @@ class ApplicationSubmissionsController < ApplicationController
   end
 
   def create_unavailability(record)
-    unavail_params = parse_unavailability(params.require :unavailability)
-                     .merge application_submission: record
-    Unavailability.create unavail_params
+    up = UnavailabilityParser.new(params.require(:unavailability))
+    record.create_unavailability(up.result)
   end
 
   def find_record

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,16 +9,6 @@ module ApplicationHelper
     configured_value [:organization_name]
   end
 
-  def parse_unavailability(params)
-    attrs = Hash.new { |k, v| k[v] = [] }
-    params.select { |_, value| value == '1' }
-          .keys.each do |day_and_time|
-            day, time = day_and_time.split '_'
-            attrs[day.to_sym] << time
-          end
-    attrs
-  end
-
   def render_markdown(text)
     renderer = Redcarpet::Render::HTML.new(filter_html: true)
     markdown = Redcarpet::Markdown.new renderer

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,39 +9,6 @@ module ApplicationHelper
     configured_value [:organization_name]
   end
 
-  # A complete question data set might look like:
-  # { "prompt_0"    => "What is your name?",
-  #   "response_0"  => "Luke Starkiller",
-  #   "data_type_0" => "text",
-  #   "316"         => "316-1" }
-  # which would translate in an application record's data to:
-  # ['What is your name?', 'Luke Starkiller', 'text', 316]
-  def parse_application_data(data)
-    questions = []
-    data.each do |key, value|
-      input_types = %w[prompt response data_type]
-      input_type = input_types.find { |type| key.starts_with? type }
-      if input_type.present?
-        # the key might be "response_0" (for the first question)
-        question_index = key.split('_').last.to_i
-        questions[question_index] ||= []
-        # the position in the sub-array should match the position in input_types
-        input_type_index = input_types.index(input_type)
-        questions[question_index][input_type_index] = value
-      else
-        # the value might be "316-1" (for the first question)
-        question_id, question_index = value.split('-').map(&:to_i)
-        # questions are numbered starting at 1,
-        # but arrays are indexed starting at 0 - so subtract 1
-        question_index -= 1
-        questions[question_index] ||= []
-        # question IDs should go in the fourth position in the sub-array
-        questions[question_index][3] = question_id
-      end
-    end
-    questions
-  end
-
   def parse_unavailability(params)
     attrs = Hash.new { |k, v| k[v] = [] }
     params.select { |_, value| value == '1' }

--- a/app/pdfs/print_record_pdf.rb
+++ b/app/pdfs/print_record_pdf.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'prawn'
 require 'prawn/table'
 
 class PrintRecordPdf < Prawn::Document

--- a/app/services/application_data_parser.rb
+++ b/app/services/application_data_parser.rb
@@ -49,7 +49,7 @@ class ApplicationDataParser
   # e.g. "316-1" (for the first question)
   def store_question_id(value)
     id, index = value.split('-').map(&:to_i)
-    index -= 1 #question ids are 1-indexed
+    index -= 1 # question ids are 1-indexed
     @questions[index] ||= []
     @questions[index][INPUT_TYPES.length] = id
   end

--- a/app/services/application_data_parser.rb
+++ b/app/services/application_data_parser.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# A complete question data set might look like:
+# { "prompt_0"    => "What is your name?",
+#   "response_0"  => "Luke Starkiller",
+#   "data_type_0" => "text",
+#   "316"         => "316-1" }
+# which would translate in an application record's data to:
+# ['What is your name?', 'Luke Starkiller', 'text', 316]
+class ApplicationDataParser
+  INPUT_TYPES = %w[prompt response data_type].freeze
+
+  def initialize(data)
+    @data = data
+    @questions = []
+    @processing_complete = false
+  end
+
+  def process!
+    @questions = []
+    @data.each do |key, value|
+      if (index = data_field_index(key))
+        store_question_data(key, value, index)
+      else
+        store_question_id(value)
+      end
+    end
+    @processing_complete = true
+    @questions
+  end
+
+  def result
+    process! unless @processing_complete
+    @questions
+  end
+
+  private
+
+  def data_field_index(key)
+    INPUT_TYPES.index key.sub(/_\d+\z/, '')
+  end
+
+  def store_question_data(key, value, dindex)
+    index = key.split('_').last.to_i
+    @questions[index] ||= []
+    @questions[index][dindex] = value
+  end
+
+  # e.g. "316-1" (for the first question)
+  def store_question_id(value)
+    id, index = value.split('-').map(&:to_i)
+    index -= 1 #question ids are 1-indexed
+    @questions[index] ||= []
+    @questions[index][INPUT_TYPES.length] = id
+  end
+end

--- a/app/services/unavailability_parser.rb
+++ b/app/services/unavailability_parser.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class UnavailabilityParser
+  def initialize(data)
+    @data = data
+    @unavailability = blank_unavailability
+    @processing_complete = false
+  end
+
+  def process!
+    @unavailability = blank_unavailability
+    true_values.each_key do |day_and_time|
+      day, _, time = day_and_time.partition('_')
+      @unavailability[day.to_sym].push time
+    end
+    @processing_complete = true
+    @unavailability
+  end
+
+  def result
+    process! unless @processing_complete
+    @unavailability
+  end
+
+  private
+
+  def blank_unavailability
+    Hash.new { |k, v| k[v] = [] }
+  end
+
+  def true_values
+    @data.select { |_, value| value == '1' }
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,32 +3,6 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
-  describe 'parse_application_data' do
-    let :input do
-      { 'prompt_0' => 'What is your name?',
-        'response_0' => 'Luke Starkiller',
-        'data_type_0' => 'text',
-        '316' => '316-1' }
-    end
-    let(:output) { parse_application_data input }
-    let(:question_data) { output.first }
-    it 'has the same size as the number of questions' do
-      expect(output.length).to be 1
-    end
-    it 'puts the prompt in position 0' do
-      expect(question_data[0]).to eql 'What is your name?'
-    end
-    it 'puts the response in position 1' do
-      expect(question_data[1]).to eql 'Luke Starkiller'
-    end
-    it 'puts the data type in position 2' do
-      expect(question_data[2]).to eql 'text'
-    end
-    it 'puts the question ID in position 3' do
-      expect(question_data[3]).to be 316
-    end
-  end
-
   describe 'parse_unavailability' do
     let :input do
       { 'sunday_7AM' => '0', 'sunday_8AM' => '0', 'tuesday_11AM' => '1',

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,26 +3,6 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
-  describe 'parse_unavailability' do
-    let :input do
-      { 'sunday_7AM' => '0', 'sunday_8AM' => '0', 'tuesday_11AM' => '1',
-        'tuesday_12AM' => '1', 'friday_4PM' => '1', 'friday_5PM' => '0' }
-    end
-    let(:output) { parse_unavailability input }
-    it 'does not select days that have no unavailabilities' do
-      expect(output.keys).not_to include :sunday
-    end
-    it 'does select days that have unavailabilities' do
-      expect(output.keys).to include :friday
-    end
-    it 'does not select available times on days with other unavailabilities' do
-      expect(output[:friday]).not_to include '5PM'
-    end
-    it 'does select times on days with unavailabilities properly' do
-      expect(output[:friday]).to include '4PM'
-    end
-  end
-
   describe 'render_markdown' do
     before :each do
       @before_markdown_input = '**Bold**'

--- a/spec/services/application_data_parser_spec.rb
+++ b/spec/services/application_data_parser_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ApplicationDataParser do
+  describe 'result' do
+    let :input do
+      { 'prompt_0' => 'What is your name?',
+        'response_0' => 'Luke Starkiller',
+        'data_type_0' => 'text',
+        '316' => '316-1' }
+    end
+    let(:output) { ApplicationDataParser.new(input).result }
+    let(:question_data) { output.first }
+
+    it 'has the same size as the number of questions' do
+      expect(output.length).to be 1
+    end
+    it 'puts the prompt in position 0' do
+      expect(question_data[0]).to eql 'What is your name?'
+    end
+    it 'puts the response in position 1' do
+      expect(question_data[1]).to eql 'Luke Starkiller'
+    end
+    it 'puts the data type in position 2' do
+      expect(question_data[2]).to eql 'text'
+    end
+    it 'puts the question ID in position 3' do
+      expect(question_data[3]).to be 316
+    end
+  end
+end

--- a/spec/services/unavailability_parser_spec.rb
+++ b/spec/services/unavailability_parser_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UnavailabilityParser do
+  describe 'result' do
+    let :input do
+      { 'sunday_7AM' => '0', 'sunday_8AM' => '0', 'tuesday_11AM' => '1',
+        'tuesday_12AM' => '1', 'friday_4PM' => '1', 'friday_5PM' => '0' }
+    end
+    let(:output) { UnavailabilityParser.new(input).result }
+    it 'does not select days that have no unavailabilities' do
+      expect(output.keys).not_to include :sunday
+    end
+    it 'does select days that have unavailabilities' do
+      expect(output.keys).to include :friday
+    end
+    it 'does not select available times on days with other unavailabilities' do
+      expect(output[:friday]).not_to include '5PM'
+    end
+    it 'does select times on days with unavailabilities properly' do
+      expect(output[:friday]).to include '4PM'
+    end
+  end
+end


### PR DESCRIPTION
Rubocop was particularly up-in-arms about `ApplicationHelper#parse_application_data` with good reason. ABC size of 23 out of an allowed 20 (which is, itself a standard we relaxed for ourselves).

I decided helpers weren't the right place for this functionality anyways (as evidenced by the face that we had to `include` said helper in the controller. Went with a pair of service objects instead.