### PR TITLE
Add Saving Interviews For Later

### DIFF
--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -62,15 +62,15 @@ class ApplicationSubmissionsController < ApplicationController
   end
 
   def toggle_saved_for_later
-   @interview = @record.interview
-   if @interview.present?
-    flash[:message] = 'Interview successfully updated' if @interview.update save_for_later_params
-   elsif @record.update save_for_later_params
-    flash[:message] = 'Application successfully updated'
-   else
-    flash[:errors] = @record.errors.full_messages
-   end
-   redirect_to staff_dashboard_path
+    @interview = @record.interview
+    if @interview.present?
+     flash[:message] = 'Interview successfully updated' if @interview.update save_for_later_params
+    elsif @record.update save_for_later_params
+     flash[:message] = 'Application successfully updated'
+    else
+     flash[:errors] = @record.errors.full_messages
+    end
+    redirect_to staff_dashboard_path
   end
 
   def show
@@ -126,12 +126,12 @@ class ApplicationSubmissionsController < ApplicationController
   def save_for_later_params
     if @record.interview.present?
       parameters = params.require(:interview).permit(
-       :note_for_later, :date_for_later
-    )
+        :note_for_later, :date_for_later
+     )
     else
       parameters = params.require(:application_submission).permit(
-      :note_for_later, :mail_note_for_later, :date_for_later, :email_to_notify
-    )
+        :note_for_later, :mail_note_for_later, :date_for_later, :email_to_notify
+     )
       parameters[:mail_note_for_later] = parameters[:mail_note_for_later] == '1'
     end
     parameters[:saved_for_later] = params[:commit] == 'Save for later'

--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -64,11 +64,11 @@ class ApplicationSubmissionsController < ApplicationController
   def toggle_saved_for_later
     @interview = @record.interview
     if @interview.present?
-     flash[:message] = 'Interview successfully updated' if @interview.update save_for_later_params
+      flash[:message] = 'Interview successfully updated' if @interview.update save_for_later_params
     elsif @record.update save_for_later_params
-     flash[:message] = 'Application successfully updated'
+      flash[:message] = 'Application successfully updated'
     else
-     flash[:errors] = @record.errors.full_messages
+      flash[:errors] = @record.errors.full_messages
     end
     redirect_to staff_dashboard_path
   end
@@ -127,11 +127,11 @@ class ApplicationSubmissionsController < ApplicationController
     if @record.interview.present?
       parameters = params.require(:interview).permit(
         :note_for_later, :date_for_later
-     )
+      )
     else
       parameters = params.require(:application_submission).permit(
         :note_for_later, :mail_note_for_later, :date_for_later, :email_to_notify
-     )
+      )
       parameters[:mail_note_for_later] = parameters[:mail_note_for_later] == '1'
     end
     parameters[:saved_for_later] = params[:commit] == 'Save for later'

--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -62,7 +62,12 @@ class ApplicationSubmissionsController < ApplicationController
   end
 
   def toggle_saved_for_later
-    if @record.update save_for_later_params
+   @interview = @record.interview
+   if @interview.present?
+     if @interview.update save_for_later_params
+       flash[:message] = 'Interview successfully updated'
+     end
+   elsif @record.update save_for_later_params
       flash[:message] = 'Application successfully updated'
     else
       flash[:errors] = @record.errors.full_messages
@@ -121,11 +126,17 @@ class ApplicationSubmissionsController < ApplicationController
   end
 
   def save_for_later_params
-    parameters = params.require(:application_submission).permit(
+    if @record.interview.present?
+      parameters = params.require(:interview).permit(
+      :note_for_later, :date_for_later
+      )
+    else
+      parameters = params.require(:application_submission).permit(
       :note_for_later, :mail_note_for_later, :date_for_later, :email_to_notify
-    )
+      )
+      parameters[:mail_note_for_later] = parameters[:mail_note_for_later] == '1'
+    end
     parameters[:saved_for_later] = params[:commit] == 'Save for later'
-    parameters[:mail_note_for_later] = parameters[:mail_note_for_later] == '1'
     if parameters[:date_for_later].present?
       parameters[:date_for_later] = Date.strptime(
         parameters[:date_for_later], '%m/%d/%Y'

--- a/app/controllers/application_submissions_controller.rb
+++ b/app/controllers/application_submissions_controller.rb
@@ -64,15 +64,13 @@ class ApplicationSubmissionsController < ApplicationController
   def toggle_saved_for_later
    @interview = @record.interview
    if @interview.present?
-     if @interview.update save_for_later_params
-       flash[:message] = 'Interview successfully updated'
-     end
+    flash[:message] = 'Interview successfully updated' if @interview.update save_for_later_params
    elsif @record.update save_for_later_params
-      flash[:message] = 'Application successfully updated'
-    else
-      flash[:errors] = @record.errors.full_messages
-    end
-    redirect_to staff_dashboard_path
+    flash[:message] = 'Application successfully updated'
+   else
+    flash[:errors] = @record.errors.full_messages
+   end
+   redirect_to staff_dashboard_path
   end
 
   def show
@@ -128,12 +126,12 @@ class ApplicationSubmissionsController < ApplicationController
   def save_for_later_params
     if @record.interview.present?
       parameters = params.require(:interview).permit(
-      :note_for_later, :date_for_later
-      )
+       :note_for_later, :date_for_later
+    )
     else
       parameters = params.require(:application_submission).permit(
       :note_for_later, :mail_note_for_later, :date_for_later, :email_to_notify
-      )
+    )
       parameters[:mail_note_for_later] = parameters[:mail_note_for_later] == '1'
     end
     parameters[:saved_for_later] = params[:commit] == 'Save for later'

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -23,7 +23,8 @@ class DashboardController < ApplicationController
                                           .group_by(&:position)
     @saved_interviews = []
     Interview.where(saved_for_later: true).each do |interview|
-      @saved_interviews.push(ApplicationSubmission.find(interview.application_submission_id)) if interview.saved_for_later
+      @saved_interviews.push(ApplicationSubmission
+        .find(interview.application_submission_id)) if interview.saved_for_later
     end
     @saved_interviews = @saved_interviews.group_by(&:position)
     @staff = User.staff

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -14,7 +14,8 @@ class DashboardController < ApplicationController
 
   def staff
     @departments = Department.includes :positions
-    @pending_interviews = Interview.pending.group_by(&:position)
+    @pending_interviews = Interview.where(saved_for_later: false)
+                                   .pending.group_by(&:position)                      
     @pending_records = ApplicationSubmission.where(saved_for_later: false)
                                             .pending.newest_first
                                             .group_by(&:position)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -20,6 +20,11 @@ class DashboardController < ApplicationController
                                             .group_by(&:position)
     @saved_records = ApplicationSubmission.where(saved_for_later: true)
                                           .group_by(&:position)
+    @saved_interviews = Array.new
+    Interview.where(saved_for_later: true).each do |interview|
+      @saved_interviews.push(ApplicationSubmission.find(interview.application_submission_id)) if interview.saved_for_later
+    end
+    @saved_interviews = @saved_interviews.group_by(&:position)
     @staff = User.staff
     @templates = ApplicationTemplate.all.group_by(&:position)
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -15,7 +15,7 @@ class DashboardController < ApplicationController
   def staff
     @departments = Department.includes :positions
     @pending_interviews = Interview.where(saved_for_later: false)
-                                   .pending.group_by(&:position)                      
+                                   .pending.group_by(&:position)
     @pending_records = ApplicationSubmission.where(saved_for_later: false)
                                             .pending.newest_first
                                             .group_by(&:position)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -21,7 +21,7 @@ class DashboardController < ApplicationController
                                             .group_by(&:position)
     @saved_records = ApplicationSubmission.where(saved_for_later: true)
                                           .group_by(&:position)
-    @saved_interviews = Array.new
+    @saved_interviews = []
     Interview.where(saved_for_later: true).each do |interview|
       @saved_interviews.push(ApplicationSubmission.find(interview.application_submission_id)) if interview.saved_for_later
     end

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -25,6 +25,11 @@ class PositionsController < ApplicationController
     @saved = @position.application_submissions.where(saved_for_later: true)
   end
 
+  def saved_interviews
+    @saved = Array.new
+    @saved = @saved_interviews.where(position: @position) if @saved_interviews != nil
+  end
+
   def edit
     @subscriptions = Subscription.where user: @current_user,
                                         position: @position

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -4,7 +4,9 @@ class PositionsController < ApplicationController
   before_action :find_position, only: %i[destroy
                                          edit
                                          update
-                                         saved_applications]
+                                         saved_applications
+                                         saved_interviews
+                                       ]
 
   def create
     @position = Position.new position_parameters
@@ -26,8 +28,8 @@ class PositionsController < ApplicationController
   end
 
   def saved_interviews
-    @saved = Array.new
-    @saved = @saved_interviews.where(position: @position) if @saved_interviews != nil
+    @saved = @position.application_submissions.where(saved_for_later: false)
+                      .each_with_object([]) { |x,arr| arr.push(x) if x.interview.present? && x.interview.saved_for_later }
   end
 
   def edit

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -6,7 +6,7 @@ class PositionsController < ApplicationController
                                          update
                                          saved_applications
                                          saved_interviews
-                                       ]
+                                        ]
 
   def create
     @position = Position.new position_parameters
@@ -29,7 +29,9 @@ class PositionsController < ApplicationController
 
   def saved_interviews
     @saved = @position.application_submissions.where(saved_for_later: false)
-                      .each_with_object([]) { |x,arr| arr.push(x) if x.interview.present? && x.interview.saved_for_later }
+                      .each_with_object([]) {
+                        |x, arr| arr.push(x) if x.interview.present? && x.interview.saved_for_later
+                      }
   end
 
   def edit

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -5,8 +5,7 @@ class PositionsController < ApplicationController
                                          edit
                                          update
                                          saved_applications
-                                         saved_interviews
-                                        ]
+                                         saved_interviews]
 
   def create
     @position = Position.new position_parameters

--- a/app/views/application_submissions/_save_for_later.html.haml
+++ b/app/views/application_submissions/_save_for_later.html.haml
@@ -1,8 +1,11 @@
-- if @record.saved_for_later?
+- temprecord = @record
+- if @record.interview.present?
+  - temprecord = @interview
+- if temprecord.saved_for_later?
   %h3 Application saved for later
 - else
   %h3 Save application for later review
-= form_with model: @record,
+= form_with model: temprecord,
   url: { action: :toggle_saved_for_later},
   local: true do |form|
   .form-group
@@ -18,7 +21,7 @@
       = form.label :date_for_later, 'Select a date for later review'
       = form.text_field :date_for_later, class: 'datepicker form-control',
         placeholder: 'Click here to select date...'
-      %i If a date is selected, the application will 
+      %i If a date is selected, the application will
       %i move back onto the dashboard at that time.
     .form-group.col
       #notification
@@ -27,6 +30,6 @@
           placeholder: 'person@example.com',
           class: 'form-control'
   .form-group
-    - if @record.saved_for_later?
+    - if temprecord.saved_for_later?
       = submit_tag 'Move back to dashboard', class: 'btn btn-primary'
     = submit_tag 'Save for later', class: 'btn btn-primary'

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -62,6 +62,8 @@
     - if @interview.pending?
       %p Interview is scheduled for: #{@interview.information}
       %p
+        = render 'save_for_later', locals: { record: @record }
+      %p
         = link_to 'Click here for a calendar export file',
           interview_path(@interview, format: :ics)
       %h3 Reschedule interview

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -13,9 +13,12 @@
       class: 'btn btn-primary'
 - if !@record.saved_for_later? && @record.note_for_later.present?
   %p
-    %i This application had previously been saved for later review. Your note:
+    %i This application/interview had previously been saved for later review. Your note(s):
   %p
     = @record.note_for_later
+  - if @record.interview.present?
+    %p
+      = @interview.note_for_later
 %table.table.table-bordered.application-record-table
   %thead
     %tr
@@ -62,7 +65,7 @@
     - if @interview.pending?
       %p Interview is scheduled for: #{@interview.information}
       %p
-        = render 'save_for_later', locals: { record: @record }
+        = render 'save_for_later', locals: { record: @interview }
       %p
         = link_to 'Click here for a calendar export file',
           interview_path(@interview, format: :ics)

--- a/app/views/dashboard/_pending_interviews.haml
+++ b/app/views/dashboard/_pending_interviews.haml
@@ -11,3 +11,10 @@
                 interview.application_submission
           - else
             No pending interviews
+        %ul
+          - if @saved_interviews[position].present?
+            - count = @saved_interviews[position].count
+            =link_to "View saved interviews for #{position.name} (#{count})",
+              saved_interviews_position_path(position)
+          - else
+            No saved interviews

--- a/app/views/positions/saved_interviews.haml
+++ b/app/views/positions/saved_interviews.haml
@@ -1,0 +1,18 @@
+%table.table.data_table.display#main_data_table
+  %thead
+    %tr
+      %th Date submitted
+      %th Name
+      %th Note
+      %th Date to review
+  %tbody
+    - @saved.each do |record|
+      %tr
+        %td{ data: { order: record.created_at.to_i } }
+          = record.created_at.to_formatted_s :long_with_time
+        %td
+          = link_to(record.user.proper_name, application_submission_path(record.id))
+        %td
+          = record.note_for_later
+        %td
+          = record.date_for_later.to_formatted_s(:long) if record.date_for_later.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
   resources :positions, except: [:index, :show] do
     member do
       get :saved_applications
+      get :saved_interviews
     end
   end
 

--- a/db/migrate/20210607173100_add_saving_for_interviews.rb
+++ b/db/migrate/20210607173100_add_saving_for_interviews.rb
@@ -1,0 +1,7 @@
+class AddSavingForInterviews < ActiveRecord::Migration[6.1]
+  def change
+    add_column :interviews, :saved_for_later, :tinyint, :default => 0
+    add_column :interviews, :note_for_later, :text, :default => nil
+    add_column :interviews, :date_for_later, :date, :default => nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_153739) do
+ActiveRecord::Schema.define(version: 2021_06_07_173100) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_02_25_153739) do
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -98,6 +99,9 @@ ActiveRecord::Schema.define(version: 2021_02_25_153739) do
     t.boolean "completed", default: false
     t.string "location"
     t.text "interview_note"
+    t.integer "saved_for_later", limit: 1, default: 0
+    t.text "note_for_later"
+    t.date "date_for_later"
     t.index ["application_submission_id"], name: "index_interviews_on_application_submission_id"
     t.index ["user_id"], name: "index_interviews_on_user_id"
   end
@@ -161,4 +165,5 @@ ActiveRecord::Schema.define(version: 2021_02_25_153739) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
Adds ability for staff to save interviews for later, temporarily removing these interviews from the dashboard to reduce clutter. Closes #431 