### PR TITLE
insure -> ensure in application_templates

### DIFF
--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -131,7 +131,7 @@
       .explanation
         The University of Massachusetts and the Pioneer Valley
         Transit Authority are equal opportunity employers. To help
-        us insure that we are complying with EEO policies, please supply
+        us ensure that we are complying with EEO policies, please supply
         the information requested below.
       .form-group
         = label_tag :ethnicity,


### PR DESCRIPTION
Small spelling fix in the view for showing application_templates. Closes #191 