### PR TITLE
Change draft relationship

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -15,8 +15,7 @@ class ApplicationDraftsController < ApplicationController
 
   def new
     template = ApplicationTemplate.find(params.require :application_template_id)
-    @draft = template.create_draft(@current_user) ||
-             template.draft_belonging_to(@current_user)
+    @draft = template.create_draft(@current_user) || template.draft
     redirect_to edit_draft_path(@draft)
   end
 

--- a/app/controllers/application_templates_controller.rb
+++ b/app/controllers/application_templates_controller.rb
@@ -48,8 +48,7 @@ class ApplicationTemplatesController < ApplicationController
                    default: 'EEO data requests disabled on this application.'
     end
     if @template.draft_belonging_to? @current_user
-      draft = @template.draft_belonging_to @current_user
-      back_path = edit_draft_path(draft)
+      back_path = edit_draft_path(@template.draft)
     else
       back_path = application_path(@template)
     end
@@ -71,8 +70,7 @@ class ApplicationTemplatesController < ApplicationController
                             this application.'
     end
     if @template.draft_belonging_to? @current_user
-      draft = @template.draft_belonging_to @current_user
-      back_path = edit_draft_path(draft)
+      back_path = edit_draft_path(@template.draft)
     else
       back_path = application_path(@template)
     end
@@ -93,8 +91,7 @@ class ApplicationTemplatesController < ApplicationController
                             this application.'
     end
     if @template.draft_belonging_to? @current_user
-      draft = @template.draft_belonging_to @current_user
-      back_path = edit_draft_path(draft)
+      back_path = edit_draft_path(@template.draft)
     else
       back_path = application_path(@template)
     end

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -7,8 +7,7 @@ class ApplicationDraft < ApplicationRecord
   belongs_to :locked_by, class_name: 'User', foreign_key: :user_id
   delegate :position, to: :application_template
 
-  validates :application_template, uniqueness: { scope: :user_id }
-  validates :application_template, :user, presence: true
+  validates :application_template, presence: true
 
   def move_question(question_number, direction)
     transaction do

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -4,7 +4,7 @@ class ApplicationDraft < ApplicationRecord
   has_many :questions, dependent: :destroy
   accepts_nested_attributes_for :questions
   belongs_to :application_template
-  belongs_to :user
+  belongs_to :locked_by, class_name: 'User', foreign_key: :user_id
   delegate :position, to: :application_template
 
   validates :application_template, uniqueness: { scope: :user_id }

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -9,6 +9,10 @@ class ApplicationDraft < ApplicationRecord
 
   validates :application_template, presence: true
 
+  def unlocked_for?(user)
+    locked_by == user
+  end
+
   def move_question(question_number, direction)
     transaction do
       question = questions.find_by number: question_number

--- a/app/models/application_template.rb
+++ b/app/models/application_template.rb
@@ -5,9 +5,8 @@ class ApplicationTemplate < ApplicationRecord
   friendly_id :department_and_position, use: :slugged
 
   has_many :questions, dependent: :destroy
-  has_many :drafts, class_name: 'ApplicationDraft',
-                    dependent: :destroy,
-                    inverse_of: :application_template
+  has_one :draft, class_name: 'ApplicationDraft', dependent: :destroy,
+                  inverse_of: :application_template
   accepts_nested_attributes_for :questions
 
   belongs_to :position

--- a/app/models/application_template.rb
+++ b/app/models/application_template.rb
@@ -35,12 +35,8 @@ class ApplicationTemplate < ApplicationRecord
     draft
   end
 
-  def draft_belonging_to(user)
-    drafts.find_by user_id: user.id
-  end
-
   def draft_belonging_to?(user)
-    draft_belonging_to(user).present?
+    draft.present? && draft.unlocked_for?(user)
   end
 
   def department_and_position

--- a/app/models/application_template.rb
+++ b/app/models/application_template.rb
@@ -14,6 +14,7 @@ class ApplicationTemplate < ApplicationRecord
 
   validates :position, presence: true, uniqueness: true
   validates :active, inclusion: { in: [true, false] }
+  validate :just_one_draft
 
   def create_draft(user)
     return false if draft_belonging_to?(user)
@@ -45,5 +46,11 @@ class ApplicationTemplate < ApplicationRecord
   def department_and_position
     [department.name.parameterize,
      position.name.parameterize].join('-')
+  end
+
+  def just_one_draft
+    if ApplicationDraft.where(application_template: self).count > 1
+      errors.add(:draft, 'Applications cannot have more than one draft')
+    end
   end
 end

--- a/app/models/application_template.rb
+++ b/app/models/application_template.rb
@@ -16,10 +16,10 @@ class ApplicationTemplate < ApplicationRecord
   validates :active, inclusion: { in: [true, false] }
   validate :just_one_draft
 
-  def create_draft(user)
-    return false if draft_belonging_to?(user)
+  def create_draft(locked_by)
+    return false if draft_belonging_to? locked_by
 
-    draft = ApplicationDraft.create user: user, application_template: self
+    draft = ApplicationDraft.create application_template: self, locked_by: locked_by
     draft_attributes = draft.attributes.keys
     template_attributes = attributes.keys
     excluded = %w[id created_at updated_at]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,18 +7,11 @@ class User < ApplicationRecord
   has_many :positions, through: :subscriptions
   has_many :application_drafts, dependent: :nullify
 
-  validates :email,
-            :first_name,
-            :last_name,
-            :spire,
-            presence: true
+  validates :email, :first_name, :last_name, :spire, presence: true
   validates :email,
             format: { with: /\A([^@\s]+)@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})\Z/ }
-  validates :staff, inclusion: { in: [true, false],
-                                 message: 'must be true or false' }
-  validates :spire,
-            uniqueness: { case_sensitive: false },
-            format: { with: /\A\d{8}@umass\.edu\z/ }
+  validates :staff, inclusion: { in: [true, false], message: 'must be true or false' }
+  validates :spire, uniqueness: { case_sensitive: false }, format: { with: /\A\d{8}@umass\.edu\z/ }
 
   default_scope { order :last_name, :first_name }
   scope :staff,    -> { where staff: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :application_submissions, dependent: :destroy
   has_many :subscriptions, dependent: :destroy
   has_many :positions, through: :subscriptions
+  has_many :application_drafts, dependent: :nullify
 
   validates :email,
             :first_name,

--- a/app/views/application_drafts/edit.haml
+++ b/app/views/application_drafts/edit.haml
@@ -1,3 +1,13 @@
-= render 'action_items'
-%h1 Editing #{@draft.position.name_and_department}
-= render partial: 'form', locals: {draft: @draft}
+- if @draft.unlocked_for? @current_user
+  %p
+    %i.text-danger
+      This application is now locked for editing to your user profile.
+      No one else may edit it until you save and publish the application.
+  = render 'action_items'
+  %h1 Editing #{@draft.position.name_and_department}
+  = render partial: 'form', locals: {draft: @draft}
+- else
+  %p
+    %i.text-danger
+      This application is locked for editing by #{@draft.locked_by.full_name}.
+      No one else may edit it until they save and publish, or discard their draft.

--- a/app/views/application_drafts/show.haml
+++ b/app/views/application_drafts/show.haml
@@ -1,4 +1,8 @@
 %i This is a preview of your changes. This form, as shown here, is not live.
+%p
+%i.text-danger
+  This application is now locked for editing to your user profile.
+  No one else may edit it until you save and publish the application.
 
 %h1 Application for #{@draft.position.name_and_department}
 - if @draft.email.present?

--- a/app/views/dashboard/_application_templates.haml
+++ b/app/views/dashboard/_application_templates.haml
@@ -9,13 +9,13 @@
             - template = @templates[position].first
             %li= link_to 'View application', application_path(template)
             %li
-              - if template.draft_belonging_to? @current_user
-                - draft = template.draft_belonging_to @current_user
-                = link_to 'Resume editing saved draft',
-                  edit_draft_path(draft)
-                = button_to 'Discard saved draft',
-                  draft_path(draft), method: :delete,
-                  class: 'btn btn-secondary'
+              - if template.draft.present?
+                - if template.draft.unlocked_for? @current_user
+                  = link_to 'Resume editing saved draft', edit_draft_path(template.draft)
+                  = button_to 'Discard saved draft', draft_path(template.draft), method: :delete,
+                    class: 'btn btn-secondary'
+                - else
+                  This application is currently being edited by #{template.draft.locked_by.full_name}
               - else
                 = link_to 'Edit application',
                   new_draft_path(application_template_id: template.id)

--- a/app/views/dashboard/_application_templates.haml
+++ b/app/views/dashboard/_application_templates.haml
@@ -7,8 +7,7 @@
         %ul
           - if @templates.key? position
             - template = @templates[position].first
-            %li= link_to 'View application',
-              application_path(template)
+            %li= link_to 'View application', application_path(template)
             %li
               - if template.draft_belonging_to? @current_user
                 - draft = template.draft_belonging_to @current_user

--- a/app/views/dashboard/_application_templates.haml
+++ b/app/views/dashboard/_application_templates.haml
@@ -17,8 +17,6 @@
                 - else
                   This application is currently being edited by #{template.draft.locked_by.full_name}
               - else
-                = link_to 'Edit application',
-                  new_draft_path(application_template_id: template.id)
+                = link_to 'Edit application', new_draft_path(application_template_id: template.id)
           - else # position has no template... yet
-            %li= link_to 'Create application',
-                  new_application_path(position_id: position.id)
+            %li= link_to 'Create application', new_application_path(position_id: position.id)

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -83,14 +83,12 @@ describe ApplicationDraftsController do
       context 'no pre-existing draft' do
         it 'creates a draft for the correct application template' do
           expect { submit }
-            .to change { @template.drafts.count }
-            .by 1
+            .to change { ApplicationDraft.where(application_template: @template).count }.by 1
         end
       end
       context 'pre-existing draft' do
         it 'finds the pre-existing draft' do
-          draft = create :application_draft,
-                         application_template: @template, user: @user
+          draft = create :application_draft, application_template: @template, locked_by: @user
           submit
           expect(assigns.fetch :draft).to eql draft
         end

--- a/spec/controllers/application_templates_controller_spec.rb
+++ b/spec/controllers/application_templates_controller_spec.rb
@@ -26,7 +26,7 @@ describe ApplicationTemplatesController do
       it 'creates a draft for that application template for the current user' do
         submit
         draft = assigns.fetch :draft
-        expect(draft.user).to eql @user
+        expect(draft.locked_by).to eql @user
       end
       it 'assigns the created draft to a draft variable' do
         draft = create :application_draft
@@ -177,10 +177,9 @@ describe ApplicationTemplatesController do
         context 'draft belonging to current user' do
           it 'redirects to the edit path' do
             @template.create_draft @user
+            @template.reload
             submit
-            expect(response).to redirect_to(
-              edit_draft_path(@template.draft_belonging_to @user)
-            )
+            expect(response).to redirect_to(edit_draft_path(@template.draft))
           end
         end
         context 'no draft belonging to current user' do
@@ -244,10 +243,9 @@ describe ApplicationTemplatesController do
         context 'draft belonging to current user' do
           it 'redirects to the edit path' do
             @template.create_draft @user
+            @template.reload
             submit
-            expect(response).to redirect_to(
-              edit_draft_path(@template.draft_belonging_to @user)
-            )
+            expect(response).to redirect_to(edit_draft_path(@template.draft))
           end
         end
         context 'no draft belonging to current user' do
@@ -311,10 +309,9 @@ describe ApplicationTemplatesController do
         context 'draft belonging to current user' do
           it 'redirects to the edit path' do
             @template.create_draft @user
+            @template.reload
             submit
-            expect(response).to redirect_to(
-              edit_draft_path(@template.draft_belonging_to @user)
-            )
+            expect(response).to redirect_to(edit_draft_path(@template.draft))
           end
         end
         context 'no draft belonging to current user' do

--- a/spec/factories/application_drafts.rb
+++ b/spec/factories/application_drafts.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :application_draft do
     application_template
-    user
+    association :locked_by, factory: :user
   end
 end

--- a/spec/models/application_template_spec.rb
+++ b/spec/models/application_template_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationTemplate do
       before :each do
         create :application_draft,
                application_template: @application_template,
-               user: @user
+               locked_by: @user
       end
       it 'returns false' do
         expect(call).to be false
@@ -30,8 +30,8 @@ describe ApplicationTemplate do
       it 'returns the draft' do
         expect(call).to be_a ApplicationDraft
       end
-      it 'sets the user of the draft to the user argument' do
-        expect(call.user).to eql @user
+      it 'sets the locked_by aspect of the draft to the user argument' do
+        expect(call.locked_by).to eql @user
       end
       it 'sets the email of the draft to be same as template email' do
         expect(call.email).to eql @application_template.email
@@ -42,23 +42,6 @@ describe ApplicationTemplate do
       it 'adds the questions of the application template to the draft' do
         expect(call.questions.size).to eql @application_template.questions.size
       end
-    end
-  end
-  describe 'draft_belonging_to' do
-    before :each do
-      @user = create :user
-      other_user = create :user
-      @application_template = create :application_template
-      @draft = create :application_draft,
-                      application_template: @application_template,
-                      user: @user
-      # other draft
-      create :application_draft,
-             application_template: @application_template,
-             user: other_user
-    end
-    it 'returns the application template draft belonging to the user' do
-      expect(@application_template.draft_belonging_to @user).to eql @draft
     end
   end
 
@@ -74,8 +57,7 @@ describe ApplicationTemplate do
       expect(call).to be false
     end
     it 'returns true if a draft does exist for the user in question' do
-      create :application_draft, user: @user,
-                                 application_template: @application_template
+      create :application_draft, locked_by: @user, application_template: @application_template
       expect(call).to be true
     end
   end

--- a/spec/system/application_draft_edit_spec.rb
+++ b/spec/system/application_draft_edit_spec.rb
@@ -3,21 +3,13 @@
 require 'rails_helper'
 
 describe 'editing application draft' do
-  let!(:draft) { create :application_draft }
-  let!(:top_question) do
-    create :question, number: 1,
-                      application_draft: draft
-  end
-  let!(:middle_question) do
-    create :question, number: 2,
-                      application_draft: draft
-  end
-  let!(:bottom_question) do
-    create :question, number: 3,
-                      application_draft: draft
-  end
+  let(:user) { create :user, staff: true }
+  let!(:draft) { create :application_draft, locked_by: user }
+  let!(:top_question) { create :question, number: 1, application_draft: draft }
+  let!(:middle_question) { create :question, number: 2, application_draft: draft }
+  let!(:bottom_question) { create :question, number: 3, application_draft: draft }
   before :each do
-    when_current_user_is :staff
+    when_current_user_is user
     visit edit_draft_path(draft)
   end
 

--- a/spec/system/application_draft_review_spec.rb
+++ b/spec/system/application_draft_review_spec.rb
@@ -21,13 +21,13 @@ describe 'previewing an application draft' do
     it 'has a button to save the application' do
       click_button('Save application')
       expect(template.reload.questions).to include question
-      expect(template.drafts).to be_empty
+      expect(template.draft).to be_nil
     end
     it 'has a button to discard changes' do
-      expect(template.drafts.first).to eql draft
+      expect(template.draft).to eql draft
       click_button('Discard changes')
       template.reload
-      expect(template.drafts).to be_empty
+      expect(template.draft).to be_nil
       expect(page.current_path).to eql staff_dashboard_path
     end
     it 'has a disabled submit button' do

--- a/spec/system/toggle_active_application_template_spec.rb
+++ b/spec/system/toggle_active_application_template_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 describe 'toggling the active attribute of application templates' do
+  let(:user) { create :user, staff: true }
   let(:application) { create :application_template }
-  let(:draft) { create :application_draft, application_template: application }
+  let(:draft) { create :application_draft, application_template: application, locked_by: user }
   before :each do
-    when_current_user_is :staff
+    when_current_user_is user
   end
   context 'on application template page' do
     before :each do

--- a/spec/system/toggle_unavailability_enabled_spec.rb
+++ b/spec/system/toggle_unavailability_enabled_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 describe 'toggle the unavailability_enabled attribute of templates' do
+  let(:user) { create :user, staff: true }
   let(:application) { create :application_template }
-  let(:draft) { create :application_draft, application_template: application }
+  let(:draft) { create :application_draft, application_template: application, locked_by: user }
   before :each do
-    when_current_user_is :staff
+    when_current_user_is user
   end
   context 'on editing application drafts page' do
     before :each do

--- a/spec/system/viewing_application_templates_spec.rb
+++ b/spec/system/viewing_application_templates_spec.rb
@@ -8,46 +8,61 @@ describe 'viewing application forms on dashboard' do
   let!(:app_with_draft) { create :application_template }
   let!(:app_without_draft) { create :application_template }
   let!(:draft) do
-    create :application_draft,
-           application_template: app_with_draft,
-           user: user
+    create :application_draft, application_template: app_with_draft, locked_by: user
   end
   before :each do
     when_current_user_is user
     visit staff_dashboard_path
   end
   it 'has links to view the applications' do
-    click_link 'View application',
-               href: application_path(app_with_draft)
-    expect(page.current_path)
-      .to eql application_path(app_with_draft)
+    click_link 'View application', href: application_path(app_with_draft)
+    expect(page.current_path).to eql application_path(app_with_draft)
     visit staff_dashboard_path
-    click_link 'View application',
-               href: application_path(app_without_draft)
-    expect(page.current_path)
-      .to eql application_path(app_without_draft)
+    click_link 'View application', href: application_path(app_without_draft)
+    expect(page.current_path).to eql application_path(app_without_draft)
   end
   it 'has a link to edit any drafts owned by the current user' do
-    click_link 'Resume editing saved draft',
-               href: edit_draft_path(draft)
-    expect(page.current_path)
-      .to eql edit_draft_path(draft)
+    click_link 'Resume editing saved draft', href: edit_draft_path(draft)
+    expect(page.current_path).to eql edit_draft_path(draft)
   end
   it 'has links to edit the applications when a draft does not yet exist' do
     action_path = new_draft_path(application_template_id: app_without_draft.id)
-    click_link 'Edit application',
-               href: action_path
-    expect(page.current_path)
-      .to eql edit_draft_path(ApplicationDraft.all.last.id)
+    click_link 'Edit application', href: action_path
+    expect(page.current_path).to eql edit_draft_path(ApplicationDraft.all.last.id)
   end
   it 'has a link to create an application if one does not exist' do
-    click_link 'Create application',
-               href: new_application_path(position_id: position.id)
-    expect(page.current_path)
-      .to eql edit_draft_path(ApplicationDraft.all.last.id)
+    click_link 'Create application', href: new_application_path(position_id: position.id)
+    expect(page.current_path).to eql edit_draft_path(ApplicationDraft.all.last.id)
   end
   it 'has a button to discard drafts' do
-    expect { click_button 'Discard saved draft' }
-      .to change { ApplicationDraft.count }.by(-1)
+    expect { click_button 'Discard saved draft' }.to change { ApplicationDraft.count }.by(-1)
+  end
+  context 'logged in as a user the draft does not belong to' do
+    let(:another_user) { create :user, staff: true }
+    before do
+      when_current_user_is another_user
+      visit staff_dashboard_path
+    end
+    it 'has links to view the applications' do
+      click_link 'View application', href: application_path(app_with_draft)
+      expect(page.current_path).to eql application_path(app_with_draft)
+      visit staff_dashboard_path
+      click_link 'View application', href: application_path(app_without_draft)
+      expect(page.current_path).to eql application_path(app_without_draft)
+    end
+    it 'does not have a link to edit the draft' do
+      expect(page).not_to have_link 'Resume editing saved draft', href: edit_draft_path(draft)
+    end
+    it 'shows that the application is locked for editing' do
+      locked_text = "This application is currently being edited by #{draft.locked_by.full_name}"
+      expect(page).to have_text locked_text
+    end
+    it 'has a link to create an application if one does not exist' do
+      click_link 'Create application', href: new_application_path(position_id: position.id)
+      expect(page.current_path).to eql edit_draft_path(ApplicationDraft.all.last.id)
+    end
+    it 'does not have a button to discard drafts' do
+      expect(page).to_not have_button 'Discard saved draft'
+    end
   end
 end


### PR DESCRIPTION
I've always wanted to do this.

So currently, ApplicationTemplates can have multiple drafts, each owned by a different user. That means that Suzie Q can be working on their draft while Joe Schmoe is working on his. Then when they're done, they can each publish! Great, right? NO. Because the resulting application will look like whoever published last. Isn't that going to be true anyways, you say? Not entirely. Here's a scenario: If Suzie adds a question and Joe created his draft before that question was added, Joe's draft will be out of date when it's published and he'll unknowingly remove that question.

The only solution I could see was to make sure there was only ever one draft and only one person could be editing it at once.

It's the second part of that question I'm a little unsure about--would it be bad to have a draft that anyone could edit? Maybe I should talk to Don & company? I can easily remove the functionality where it's locked to one user.

LMK what y'all think.