### PR TITLE
Use newer version of Ubuntu on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: ruby
 cache: bundler
 services:


### PR DESCRIPTION
Yesterday, NodeJS released the first 18.x LTS, and our app just uses "lts/*". 18.x requires a version of glibc that isn't available on Xenial (Travis's default).