### PR TITLE
Remove unused code for a "calendar icon"

### DIFF
--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -12,8 +12,4 @@ $(document).ready(function(){
     format: 'dddd, MMMM D, YYYY, h:mm a',
     step: 15
   });
-
-  $('.fa-calendar').click(function(){
-    $(this).parents('.input-group').find('.datepicker').focus();
-  });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,9 +33,7 @@ body{
 .main-content{
   background-color: #fafafa;
 }
-.fa-calendar{
-  cursor: pointer;
-}
+
 h1{
   text-align: center;
 }


### PR DESCRIPTION
One of the datepickers on the site had a calendar icon attached to it that has since been removed.