### PR TITLE
Use Selenium for webdriver management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec-html-matchers'
   gem 'rspec-rails'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'timecop'
   gem 'umts-custom-matchers'
-  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (3.0.0)
     chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -304,7 +303,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby_parser (3.15.1)
       sexp_processor (~> 4.9)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -315,9 +314,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.16.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sexp_processor (4.15.2)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -351,10 +351,7 @@ GEM
     umts-custom-matchers (2.0.0)
       rspec-rails (>= 3.0, <= 6.0)
     unicode-display_width (2.5.0)
-    webdrivers (4.5.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -404,13 +401,13 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails
+  selenium-webdriver
   simplecov
   snappconfig
   spring
   timecop
   uglifier
   umts-custom-matchers
-  webdrivers
   whenever
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,6 @@ require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'rack_session_access/capybara'
-require 'webdrivers'
 
 ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
Selenium 4.11+ knows how to manage chromedriver.

The `webdrivers` gem isn't needed anymore. See umts/screaming-dinosaur#290