### PR TITLE
Only "refuse" a coverage drop in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'simplecov'
 require 'umts_custom_matchers'
 
 SimpleCov.start 'rails' do
-  refuse_coverage_drop
+  refuse_coverage_drop if ENV['CI']
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
If we just always refuse coverage, then it's harder to notice that coverage _has_, in fact, dropped since Simplecov just won't re-write the coverage file.

This way, a dev can see the change to `.last_run.json` and either fix it or commit it, at which point said drop can be discussed and perhaps justified in a code-review. But Travis will still catch when the dev _didn't_ run the specs, and the coverage dropped un-accounted-for.