### PR TITLE
Appease Spring: don't cache classes in test.

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = false
+  config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
Newer Spring started getting mad about this.

Took this recommendation from [here][1].

[1]: https://github.com/railsdiff/rails-new-output/blob/cb6a93be67c30040485603cf5b51c7dae4144251/config/environments/test.rb#L11