### PR TITLE
Second attempt at Datepicker removal

### DIFF
--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -3,11 +3,6 @@ $(function() {
   // you'll get an error
   $.datetimepicker.setDateFormatter('moment');
 
-  $('.datepicker').datetimepicker({
-    timepicker: false,
-    format: 'MM/DD/YYYY'
-  });
-
   $('.datetimepicker').datetimepicker({
     format: 'dddd, MMMM D, YYYY, h:mm a',
     step: 15

--- a/app/helpers/application_submission_helper.rb
+++ b/app/helpers/application_submission_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ApplicationSubmissionHelper
+  def format_response(response, type)
+    return '' if response.blank?
+
+    case type
+    when 'date'
+      response.to_date.to_formatted_s
+    else
+      response
+    end
+  end
+end

--- a/app/pdfs/print_record_pdf.rb
+++ b/app/pdfs/print_record_pdf.rb
@@ -4,6 +4,7 @@ require 'prawn'
 require 'prawn/table'
 
 class PrintRecordPdf
+  include ApplicationSubmissionHelper
   include Prawn::View
 
   def initialize(record)
@@ -67,7 +68,7 @@ class PrintRecordPdf
     @record.data.filter_map do |prompt, response, data_type, _id|
       next if %w[heading explanation].include? data_type
 
-      [prompt, response]
+      [prompt, format_response(response, data_type)]
     end.unshift headers
   end
 

--- a/app/views/application_drafts/show.haml
+++ b/app/views/application_drafts/show.haml
@@ -42,11 +42,10 @@
               id: index,
               class: 'form-control'
           - when 'date'
-            = r.text_field question.prompt,
+            = r.date_field question.prompt,
               required: question.required?,
-              class: 'form-control datepicker',
-              id: index,
-              placeholder: 'Click here to select date...'
+              class: 'form-control',
+              id: index
           - when 'number'
             = r.number_field question.prompt,
               required: question.required?,

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -32,7 +32,7 @@
           %i= render_markdown prompt
       - else
         %td=prompt
-      %td=response
+        %td= format_response response, data_type
 
 -if @record.unavailability.present?
   %strong Unavailability

--- a/app/views/application_templates/show.haml
+++ b/app/views/application_templates/show.haml
@@ -82,10 +82,9 @@
                 id: index,
                 value: @old_data[question.id] || ""
             - when 'date'
-              = r.text_field question.unique_name,
+              = r.date_field question.unique_name,
                 required: question.required?,
-                class: 'form-control datepicker',
-                placeholder: 'Click here to select date...',
+                class: 'form-control',
                 id: index,
                 value: @old_data[question.id] || ""
             - when 'number'

--- a/lib/tasks/application_submissions.rake
+++ b/lib/tasks/application_submissions.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+def parse_date(date)
+  return if date.blank?
+
+  begin
+    Date.strptime(date, '%m/%d/%Y')
+  rescue Date::Error
+    Date.parse(date)
+  end
+end
+
+namespace :application_submissions do
+  desc 'Correct date format for previous submissions'
+  task fix_submitted_dates: :environment do
+    ApplicationSubmission.find_each do |as|
+      as.update! data: (as.data.map do |question|
+        case question
+        in [prompt, response, 'date', id]
+          [prompt, parse_date(response)&.to_formatted_s(:db), 'date', id]
+        else
+          question
+        end
+      end)
+    end
+  end
+end

--- a/lib/tasks/application_submissions.rake
+++ b/lib/tasks/application_submissions.rake
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 def parse_date(date)
-  return if date.blank?
+  return '' if date.blank?
 
   begin
     Date.strptime(date, '%m/%d/%Y')
   rescue Date::Error
-    Date.parse(date)
+    begin
+      Date.parse(date)
+    rescue Date::Error
+      false
+    end
   end
 end
 
@@ -16,8 +20,13 @@ namespace :application_submissions do
     ApplicationSubmission.find_each do |as|
       as.update! data: (as.data.map do |question|
         case question
-        in [prompt, response, 'date', id]
-          [prompt, parse_date(response)&.to_formatted_s(:db), 'date', id]
+        in [prompt, response, 'date', *rest]
+          date = parse_date(response)
+          if date
+            [prompt, date.presence&.to_formatted_s(:db), 'date', *rest]
+          else
+            [prompt, response, 'text', *rest]
+          end
         else
           question
         end

--- a/spec/helpers/application_submission_helper_spec.rb
+++ b/spec/helpers/application_submission_helper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ApplicationSubmissionHelper do
+  describe 'format_response' do
+    it 'is a blank string for blank responses' do
+      expect(format_response(nil, 'anything')).to eq('')
+    end
+
+    it 'formats dates' do
+      expect(format_response('2020-01-02', 'date')).to eq('01/02/2020')
+    end
+
+    it 'returns the input for all other types' do
+      string = Array.new(20) { ('a'..'z').to_a.sample }.join
+      expect(format_response(string, 'whatever')).to eq(string)
+    end
+  end
+end


### PR DESCRIPTION
Turns out there's all sorts of inconsistent data in production that I didn't account for in #539 

New changes in this PR are in 4b383dee123d5a6b2376e1d5d31a626ae7531a54:

* Not all responses are a four-element array, some are a three-element array (no `Question` id) - old task was just skipping these since they didn't match the pattern.
* Some "dates" are... not dates. Some examples include `"03/18"` `"8/2015"`, `"Fall 2020"`, `"2024"`, `"11/31/2019"` (30 days in November), `"092016"` (2016-09-20 or Sep, 2016?) etc. I decided to just call them "text" if we can't parse it into a real date.