### PR TITLE
Link `/storage` to shared dirs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,6 +11,6 @@ append :linked_files,
   'config/database.yml',
   'config/credentials/production.key'
 
-append :linked_dirs, '.bundle', 'log', 'node_modules'
+append :linked_dirs, '.bundle', 'log', 'node_modules', 'storage'
 
 set :passenger_restart_with_sudo, true


### PR DESCRIPTION
Without this, uploaded resumes get lost every deploy.