### PR TITLE
Remove "data page" shared example

### DIFF
--- a/spec/support/shared_examples/data_page_shared_example.rb
+++ b/spec/support/shared_examples/data_page_shared_example.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-shared_examples 'a data page' do |table_ids:|
-  it 'contains all required tables' do
-    table_ids.each do |table_id|
-      expect(page).to have_table table_id
-    end
-  end
-end

--- a/spec/system/viewing_past_applications_table_spec.rb
+++ b/spec/system/viewing_past_applications_table_spec.rb
@@ -31,8 +31,6 @@ describe 'viewing table of past applications' do
     click_button 'List Applications'
   end
 
-  it_behaves_like 'a data page', table_ids: %w[main_data_table]
-
   it 'goes to the past applications page' do
     expect(page.current_path)
       .to include past_applications_application_submissions_path


### PR DESCRIPTION
It isn't really "shared", and only asserts a single table id

Closes #240