### PR TITLE
Add step attributes to datetime fields

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,4 +1,6 @@
 linters:
+  LineLength:
+    max: 120
   RuboCop:
     ignored_cops:
       - Metrics/BlockNesting

--- a/app/views/application_submissions/_approve.html.haml
+++ b/app/views/application_submissions/_approve.html.haml
@@ -5,9 +5,7 @@
     .row
       .form-group.col
         = f.label :scheduled, 'Date/time'
-        = f.datetime_field :scheduled,
-          class: 'form-control',
-          size: 40, required: true
+        = f.datetime_field :scheduled, required: true, step: 60 * 15, class: 'form-control'
       .form-group.col
         = f.label :location
         = f.text_field :location,

--- a/app/views/application_submissions/show.haml
+++ b/app/views/application_submissions/show.haml
@@ -69,9 +69,7 @@
         id: @interview.id do
         .form-group
           = label_tag :scheduled, 'New interview date/time:'
-          = datetime_field_tag :scheduled, '',
-            required: true,
-            class: 'form-control'
+          = datetime_field_tag :scheduled, '', step: 60 * 15, required: true, class: 'form-control'
         .form-group
           = label_tag :location, 'New location:'
           = text_field_tag :location, @interview.location,


### PR DESCRIPTION
This is in response to a Don feedback - he is displeased that the native datepickers offer granular (down to the minute) time values and would prefer them to only offer multiples of 15.

Now this doesn't actually do that - it only affects the intervals that the arrow keys change the time. But I'd like to do something to say "we tried" before writing the "sorrrrrry but no" response.
