### PR TITLE
Don't use system libraries to build Nokogiri

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,3 @@
 server 'af-transit-app3.admin.umass.edu',
        roles: %w(app db web),
        ssh_options: { forward_agent: false }
-
-set :bundle_env_variables, { 'NOKOGIRI_USE_SYSTEM_LIBRARIES' => 1 }


### PR DESCRIPTION
Similar to umts/stop-project#368 this doesn't _do_ anything, but if it did, it wouldn't work.