### PR TITLE
Switch to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'redcarpet'
 gem 'sass-rails'
 gem 'snappconfig'
 gem 'sprockets-rails'
-gem 'uglifier'
+gem 'terser'
 gem 'whenever', require: false
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,6 +390,8 @@ GEM
     stringio (3.1.2)
     sysexits (1.2.0)
     temple (0.10.3)
+    terser (1.2.4)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.4.0)
     timecop (0.9.10)
@@ -398,8 +400,6 @@ GEM
       bigdecimal (~> 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.1.3)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -460,8 +460,8 @@ DEPENDENCIES
   snappconfig
   spring
   sprockets-rails
+  terser
   timecop
-  uglifier
   whenever
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   config.public_file_server.enabled = false
 
   # Compress JS and CSS using preprocessors.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Uglifyer fails for... some reason after #672

Must be some change in `rails-ujs`? That's the only asset file that I can see that would be changed by a Rails upgrade. I never have the energy to track-down anything that goes wrong in an execjs context; Terser is fine.