### PR TITLE
Adjust question parameter handing for drafts

### DIFF
--- a/app/controllers/application_drafts_controller.rb
+++ b/app/controllers/application_drafts_controller.rb
@@ -15,10 +15,10 @@ class ApplicationDraftsController < ApplicationController
 
   def update
     draft_params = params.require(:draft)
-    question_attributes = draft_params.require(:questions_attributes).permit!.to_h
+                         .permit(:email, questions_attributes: %i[id number prompt data_type required])
+    questions = draft_params.require(:questions_attributes).values
     @draft.update email: draft_params[:email]
-    @draft.update_questions question_attributes
-    @draft.reload # since questions have been updated
+    @draft.update_questions questions
     case params.require :commit
     when 'Save changes and continue editing'
       redirect_to edit_draft_path(@draft)

--- a/app/models/application_draft.rb
+++ b/app/models/application_draft.rb
@@ -56,10 +56,11 @@ class ApplicationDraft < ApplicationRecord
   def update_questions(question_data)
     return if question_data.blank?
 
-    questions.destroy_all
-    question_data.each_value do |question_attributes|
-      question_attributes[:application_draft_id] = id
-      Question.create question_attributes
+    transaction do
+      questions.destroy_all
+      question_data.each do |question_attributes|
+        questions.create question_attributes
+      end
     end
   end
 

--- a/spec/controllers/application_drafts_controller_spec.rb
+++ b/spec/controllers/application_drafts_controller_spec.rb
@@ -118,7 +118,7 @@ describe ApplicationDraftsController do
   describe 'POST #update' do
     before do
       @draft = create(:application_draft)
-      @question_attrs = { a_key: 'a_value' }
+      @question_attrs = { '0' => { number: 1, data_type: 'text', prompt: 'a_prompt' } }
       @draft_changes = { questions_attributes: @question_attrs }
       @commit = 'Save changes and continue editing'
     end
@@ -134,12 +134,6 @@ describe ApplicationDraftsController do
     context 'staff' do
       before do
         when_current_user_is :staff
-        # Mock it out above so that we don't get errors
-        # from the original method being invoked
-        # on an incorrect data structure
-        expect_any_instance_of(ApplicationDraft)
-          .to receive(:update_questions)
-          .with @question_attrs.stringify_keys
       end
 
       it 'assigns the correct draft variable' do
@@ -148,8 +142,8 @@ describe ApplicationDraftsController do
       end
 
       it 'updates the draft with the changes given' do
-        # mocked above
         submit
+        expect(@draft.reload.questions.first.prompt).to eql 'a_prompt'
       end
 
       context 'saving changes' do

--- a/spec/models/application_draft_spec.rb
+++ b/spec/models/application_draft_spec.rb
@@ -117,21 +117,20 @@ describe ApplicationDraft do
       @draft = create(:application_draft)
       @question = create(:question, application_draft: @draft)
       @new_prompt = 'A new prompt'
-      # keys don't matter, ignored in method
-      @question_data = {
-        0 => {
+      @question_data = [
+        {
           number: @question.number,
           prompt: 'A new prompt',
           data_type: @question.data_type,
           required: @question.required
         },
-        1 => {
+        {
           number: @question.number + 1,
           prompt: 'A prompt',
           data_type: 'text',
           required: true
         }
-      }
+      ]
     end
 
     let :call do


### PR DESCRIPTION
The primary motivator here was a Brakeman warning about `permit!` for mass-assignment. But I made a few other adjustments:

1. The `update_questions` method now takes an array rather than a hash where it only uses the values.
2. I wrapped the question swapping in a transaction
3. If you create questions with the instance's collection, you don't have to reload it

All of this _could_ be done with nested attributes and regular-old assignment. But I decided that that would be a bit more work, and could wait.