### PR TITLE
Force ruby platform for nokogiri 1.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'haml'
 gem 'haml-rails'
 gem 'icalendar'
 gem 'mysql2'
+# TODO: Remove ruby platform when we're off RHEL 7
+gem 'nokogiri', force_ruby_platform: true
 gem 'prawn'
 gem 'prawn-table'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
-    nokogiri (1.17.2)
+    nokogiri (1.18.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     ostruct (0.6.1)
@@ -442,6 +442,7 @@ DEPENDENCIES
   icalendar
   listen
   mysql2
+  nokogiri
   prawn
   prawn-table
   pry-byebug


### PR DESCRIPTION
Which needs newer glibc than we have available