### PR TITLE
Remove rb-readline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ group :development do
   gem 'capistrano-rails', require: false
   gem 'ed25519', require: false
   gem 'listen'
-  gem 'rb-readline', require: false
   gem 'rubocop', require: false
   gem 'rubocop-capybara', require: false
   gem 'rubocop-factory_bot', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rb-readline (0.5.5)
     rdoc (6.12.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
@@ -460,7 +459,6 @@ DEPENDENCIES
   rack_session_access
   rails (~> 7.1.5)
   rails-controller-testing
-  rb-readline
   redcarpet
   rspec-html-matchers
   rspec-rails
@@ -596,7 +594,6 @@ CHECKSUMS
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.10.1) sha256=050062d4f31d307cca52c3f6a7f4b946df8de25fc4bd373e1a5142e41034a7ca
-  rb-readline (0.5.5) sha256=9e9bd7e198bdef0822c46902f6c592b882c1f9777894a4c3dcf5b320824a8793
   rdoc (6.12.0) sha256=7d6f706e070bffa5d18a448f24076cbfb34923a99c1eab842aa18e6ca69f56e0
   redcarpet (3.6.0) sha256=8ad1889c0355ff4c47174af14edd06d62f45a326da1da6e8a121d59bdcd2e9e9
   regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61


### PR DESCRIPTION
This allows `require 'readline'` to work on systems without libreadline. But, we don't have any of those, and also Ruby recommends using `reline` instead. And Ruby readline support is "retired" as of Ruby 3.3