### PR TITLE
Move rubocop-rails and rubocop-rspec to plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
+
+require:
   - rubocop-rspec_rails
   - rubocop-capybara
   - rubocop-factory_bot


### PR DESCRIPTION
New versions (#703 and #705) of these gems implement the new "plugin" system for Rubocop. Having them as `require`s, still works, but emits a warning (Which our Overcommit config says is an error).