### PR TITLE
Guard against application submission destruction

### DIFF
--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -3,7 +3,7 @@
 class Position < ApplicationRecord
   belongs_to :department
   has_one :application_template, dependent: :destroy
-  has_many :application_submissions, dependent: :destroy
+  has_many :application_submissions, dependent: :restrict_with_error
   has_many :interviews, through: :application_submissions
   has_many :subscriptions, dependent: :destroy
   has_many :users, through: :subscriptions


### PR DESCRIPTION
Regarding the AVS position deletion incident

I think this makes sense as the relationship to restrict
