### PR TITLE
Add task to fill dummy entra uids

### DIFF
--- a/app/tasks/maintenance/fill_missing_entra_uids_task.rb
+++ b/app/tasks/maintenance/fill_missing_entra_uids_task.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# simplecov:disable
+module Maintenance
+  class FillMissingEntraUidsTask < MaintenanceTasks::Task
+    def collection
+      User.where(entra_uid: nil)
+    end
+
+    def process(user)
+      user.update!(entra_uid: "missing-#{user.spire.delete_suffix('@umass.edu')}")
+    end
+  end
+end
+# simplecov:enable


### PR DESCRIPTION
Second of the OAuth-migration PRs for #781, mirroring screaming-dinosaur #885. FillMissingEntraUidsTask assigns placeholder entra_uids (missing-<spire>) to any users still nil after the real backfill — the inactive accounts the Azure lookup can't resolve. Stacked on #1147.

Part of #781.
