### PR TITLE
Set up bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 ruby file: '.ruby-version'
 
+gem 'bootsnap', require: false
 gem 'cssbundling-rails'
 gem 'csv'
 gem 'friendly_id'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     bigdecimal (3.3.1)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
+    bootsnap (1.24.6)
+      msgpack (~> 1.2)
     brakeman (8.0.5)
       racc
     builder (3.3.0)
@@ -210,6 +212,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    msgpack (1.8.4)
     net-imap (0.6.6)
       date
       net-protocol
@@ -448,6 +451,7 @@ DEPENDENCIES
   bcrypt_pbkdf
   better_errors
   binding_of_caller
+  bootsnap
   brakeman
   capistrano
   capistrano-bundler
@@ -516,6 +520,7 @@ CHECKSUMS
   better_errors (2.10.1) sha256=f798f1bac93f3e775925b7fcb24cffbcf0bb62ee2210f5350f161a6b75fc0a73
   bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
   binding_of_caller (2.0.0) sha256=e53eebf8428a85587aede7b43a83e7419eb85b8b690938a96aa330d03052d517
+  bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
   brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
@@ -571,6 +576,7 @@ CHECKSUMS
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  msgpack (1.8.4) sha256=4411c22d350dd1c20250f7eada3cca2695438c2f769cf0782f0cd065d90a3e7b
   net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,5 +13,7 @@ append :linked_dirs, '.bundle', 'log', 'node_modules', 'storage'
 
 set :passenger_restart_with_sudo, true
 set :bundle_version, 4
+set :bundle_bins, fetch(:bundle_bins, []).push('bootsnap')
 
+before 'deploy:updated', 'bootsnap:precompile'
 after 'deploy:published', 'solid_queue:restart'

--- a/lib/capistrano/tasks/bootsnap.rake
+++ b/lib/capistrano/tasks/bootsnap.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :bootsnap do
+  desc 'Precompile bootsnap'
+  task :precompile do
+    on roles :app do
+      within release_path do
+        execute :bootsnap, :precompile, '--gemfile', 'config/', 'app/', 'lib/'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds bootsnap to speed up boot by caching compiled Ruby and YAML. `gem 'bootsnap', require: false` plus `require "bootsnap/setup"` in boot.rb, matching the standard Rails/screaming-dinosaur setup.

Closes #1145.
