### PR TITLE
Drop the spire column

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,13 +34,12 @@ class UsersController < ApplicationController
 
   def promote
     @users = User.where.not(staff: true)
-                 .pluck(:first_name, :last_name, :spire)
+                 .pluck(:first_name, :last_name, :id)
                  .map { |attrs| attrs.join(' ') }
   end
 
   def promote_save
-    # TODO: Use the id field to identify a user by a known id...
-    user = User.find_by(spire: params[:user].split.last) # rubocop:disable Rails/StrongParametersExpect
+    user = User.find_by(id: params[:user].split.last) # rubocop:disable Rails/StrongParametersExpect
     if user.nil?
       redirect_to promote_users_path
     elsif user.update(staff: true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,6 @@ class User < ApplicationRecord
   validates :email,
             format: { with: /\A([^@\s]+)@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})\Z/ }
   validates :staff, inclusion: { in: [true, false], message: :true_false }
-  validates :spire, uniqueness: { case_sensitive: false },
-                    format: { with: /\A\d{8}@umass\.edu\z/ }, allow_nil: true
   validates :entra_uid, presence: true, uniqueness: { case_sensitive: true }
 
   default_scope { order :last_name, :first_name }

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc, :spire, :github
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc, :github
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,10 +34,6 @@ en:
   errors:
     messages:
       true_false: 'must be true or false'
-  activerecord:
-    attributes:
-      user:
-        spire: SPIRE
   application_drafts:
     destroy:
       success: Your draft has been discarded.

--- a/db/migrate/20260820191000_drop_old_auth_columns.rb
+++ b/db/migrate/20260820191000_drop_old_auth_columns.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DropOldAuthColumns < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :users, :spire, unique: true
+    remove_column :users, :spire, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_04_212513) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_191000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -298,11 +298,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_212513) do
     t.string "entra_uid", null: false
     t.string "first_name"
     t.string "last_name"
-    t.string "spire"
     t.boolean "staff", default: false
     t.datetime "updated_at", precision: nil
     t.index ["entra_uid"], name: "index_users_on_entra_uid", unique: true
-    t.index ["spire"], name: "index_users_on_spire", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,8 @@ require 'factory_bot_rails'
 require 'csv'
 
 exit if Rails.env.test?
-FactoryBot.create :user, first_name: 'David', last_name: 'Faulkenberry', staff: true, spire: '12345678@umass.edu', email: 'dfaulken@umass.edu', admin: true
-user = FactoryBot.create :user, first_name: 'Justin', last_name: 'Forgue', spire: '13579246@umass.edu', email: 'jforgue@umass.edu'
+FactoryBot.create :user, first_name: 'David', last_name: 'Faulkenberry', staff: true, email: 'dfaulken@umass.edu', admin: true
+user = FactoryBot.create :user, first_name: 'Justin', last_name: 'Forgue', email: 'jforgue@umass.edu'
 department = FactoryBot.create :department, name: 'Bus'
 position = FactoryBot.create :position, department: department, name: 'Operator'
 FactoryBot.create :application_submission,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -68,7 +68,7 @@ describe UsersController do
       end
 
       it 'does not promote the user' do
-        put :promote_save, params: { user: "#{user.full_name} #{user.spire}" }
+        put :promote_save, params: { user: "#{user.full_name} #{user.id}" }
         user.reload
         expect(user).not_to be_staff
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     first_name { 'FirstName' }
     last_name { 'LastName' }
     staff { false }
-    sequence(:spire) { |n| format('%08d@umass.edu', n) }
     sequence(:entra_uid) { |n| "entra-uid-#{n}" }
 
     trait :staff do

--- a/spec/system/user_creation_spec.rb
+++ b/spec/system/user_creation_spec.rb
@@ -20,7 +20,7 @@ describe 'creating a staff member' do
         visit new_user_path
       end
 
-      let(:user_fields) { attributes_for(:user).except :staff, :spire }
+      let(:user_fields) { attributes_for(:user).except :staff }
 
       context 'with required fields filled in' do
         before do

--- a/spec/system/user_edit_spec.rb
+++ b/spec/system/user_edit_spec.rb
@@ -21,7 +21,7 @@ describe 'editing staff users' do
       end
 
       context 'when every field is filled in correctly' do
-        let(:attributes) { attributes_for(:user).except :staff, :last_name, :spire }
+        let(:attributes) { attributes_for(:user).except :staff, :last_name }
 
         before do
           fill_in_fields_for User, attributes: attributes.merge(first_name: 'Bananas')
@@ -43,7 +43,7 @@ describe 'editing staff users' do
       end
 
       context 'when a required field is left blank' do
-        let(:attributes) { attributes_for(:user).except(:staff, :spire) }
+        let(:attributes) { attributes_for(:user).except(:staff) }
 
         before do
           fill_in_fields_for User, attributes: attributes.merge(first_name: '')

--- a/spec/system/user_promote_spec.rb
+++ b/spec/system/user_promote_spec.rb
@@ -18,10 +18,17 @@ describe 'promoting a staff member' do
       before { visit promote_users_path }
 
       context 'with the field filled-in' do
-        it 'promotes the user' do
-          fill_in 'promote-search', with: "#{user.full_name} #{user.spire}"
+        before do
+          fill_in 'promote-search', with: "#{user.full_name} #{user.id}"
           click_on 'Promote'
+        end
+
+        it 'shows a success message' do
           expect(page).to have_text('User successfully updated.')
+        end
+
+        it 'promotes the identified user to staff' do
+          expect(user.reload).to be_staff
         end
       end
 


### PR DESCRIPTION
Drops users.spire now that OAuth (#1168) replaced Shibboleth. Mirrors
screaming-dinosaur #886. Follow-up to #781.

spire's only non-auth use was the staff-promotion search, which used it as
a unique disambiguator; it now uses the user id (satisfying the existing
TODO). Also drops the spire validation, factory sequence, seed values, i18n
label, and param filter.

Stacked on #1168. Being an irreversible column drop, it should not merge
until #1168 has shipped and prod is confirmed on OAuth (same ordering as
SD #881 then #886).